### PR TITLE
fix(notification): preserve alert cooldown state on upgrade

### DIFF
--- a/server/migrations/postgres/2026-05-04-090000_notification_channel_state/down.sql
+++ b/server/migrations/postgres/2026-05-04-090000_notification_channel_state/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS notification_channel_state;

--- a/server/migrations/postgres/2026-05-04-090000_notification_channel_state/up.sql
+++ b/server/migrations/postgres/2026-05-04-090000_notification_channel_state/up.sql
@@ -1,0 +1,49 @@
+CREATE TABLE notification_channel_state (
+    id BIGINT PRIMARY KEY,
+    alert_id BIGINT NOT NULL,
+    alert_fingerprint TEXT NOT NULL,
+    channel_id BIGINT NOT NULL,
+    event_type TEXT NOT NULL CHECK (event_type IN ('alert_fired', 'alert_recovered')),
+    occurrence_key BIGINT NOT NULL,
+    last_notification_at BIGINT NOT NULL,
+    created_at BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL,
+    UNIQUE(alert_id, channel_id, event_type),
+    FOREIGN KEY (alert_id) REFERENCES alert_event(id),
+    FOREIGN KEY (channel_id) REFERENCES notification_channel(id)
+);
+
+CREATE INDEX idx_notification_channel_state_alert
+    ON notification_channel_state (alert_fingerprint, event_type, occurrence_key);
+
+CREATE INDEX idx_notification_channel_state_channel
+    ON notification_channel_state (channel_id, event_type, last_notification_at);
+
+INSERT INTO notification_channel_state (
+    id,
+    alert_id,
+    alert_fingerprint,
+    channel_id,
+    event_type,
+    occurrence_key,
+    last_notification_at,
+    created_at,
+    updated_at
+)
+SELECT
+    ROW_NUMBER() OVER (ORDER BY alert_event.id, notification_channel.id),
+    alert_event.id,
+    alert_event.fingerprint,
+    notification_channel.id,
+    'alert_fired',
+    alert_event.reopened_count,
+    alert_event.last_notification_at,
+    alert_event.last_notification_at,
+    alert_event.last_notification_at
+FROM alert_event
+JOIN notification_channel
+    ON notification_channel.channel_type = 'webhook'
+    AND notification_channel.is_enabled = TRUE
+    AND notification_channel.deleted_at IS NULL
+WHERE alert_event.status = 'active'
+    AND alert_event.last_notification_at IS NOT NULL;

--- a/server/migrations/sqlite/2026-05-04-090000_notification_channel_state/down.sql
+++ b/server/migrations/sqlite/2026-05-04-090000_notification_channel_state/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS notification_channel_state;

--- a/server/migrations/sqlite/2026-05-04-090000_notification_channel_state/up.sql
+++ b/server/migrations/sqlite/2026-05-04-090000_notification_channel_state/up.sql
@@ -1,0 +1,49 @@
+CREATE TABLE notification_channel_state (
+    id BIGINT PRIMARY KEY NOT NULL,
+    alert_id BIGINT NOT NULL,
+    alert_fingerprint TEXT NOT NULL,
+    channel_id BIGINT NOT NULL,
+    event_type TEXT NOT NULL CHECK (event_type IN ('alert_fired', 'alert_recovered')),
+    occurrence_key BIGINT NOT NULL,
+    last_notification_at BIGINT NOT NULL,
+    created_at BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL,
+    UNIQUE(alert_id, channel_id, event_type),
+    FOREIGN KEY (alert_id) REFERENCES alert_event(id),
+    FOREIGN KEY (channel_id) REFERENCES notification_channel(id)
+);
+
+CREATE INDEX idx_notification_channel_state_alert
+    ON notification_channel_state (alert_fingerprint, event_type, occurrence_key);
+
+CREATE INDEX idx_notification_channel_state_channel
+    ON notification_channel_state (channel_id, event_type, last_notification_at);
+
+INSERT INTO notification_channel_state (
+    id,
+    alert_id,
+    alert_fingerprint,
+    channel_id,
+    event_type,
+    occurrence_key,
+    last_notification_at,
+    created_at,
+    updated_at
+)
+SELECT
+    ROW_NUMBER() OVER (ORDER BY alert_event.id, notification_channel.id),
+    alert_event.id,
+    alert_event.fingerprint,
+    notification_channel.id,
+    'alert_fired',
+    alert_event.reopened_count,
+    alert_event.last_notification_at,
+    alert_event.last_notification_at,
+    alert_event.last_notification_at
+FROM alert_event
+JOIN notification_channel
+    ON notification_channel.channel_type = 'webhook'
+    AND notification_channel.is_enabled = TRUE
+    AND notification_channel.deleted_at IS NULL
+WHERE alert_event.status = 'active'
+    AND alert_event.last_notification_at IS NOT NULL;

--- a/server/src/database/alert.rs
+++ b/server/src/database/alert.rs
@@ -291,6 +291,23 @@ pub fn list_alerts(filter: AlertListFilter) -> DbResult<Vec<AlertEvent>> {
     })
 }
 
+pub fn list_active_alerts_for_evaluation() -> DbResult<Vec<AlertEvent>> {
+    let conn = &mut get_connection()?;
+    db_execute!(conn, {
+        alert_event::table
+            .filter(alert_event::dsl::status.eq(ALERT_STATUS_ACTIVE))
+            .order(alert_event::dsl::last_seen_at.desc())
+            .select(AlertEventDb::as_select())
+            .load::<AlertEventDb>(conn)
+            .map(|rows| rows.into_iter().map(AlertEventDb::from_db).collect())
+            .map_err(|err| {
+                BaseError::DatabaseFatal(Some(format!(
+                    "Failed to list active alerts for evaluation: {err}"
+                )))
+            })
+    })
+}
+
 pub fn acknowledge_alert(alert_id: i64, note: Option<String>, now_ms: i64) -> DbResult<AlertEvent> {
     let conn = &mut get_connection()?;
     db_execute!(conn, {

--- a/server/src/database/notification.rs
+++ b/server/src/database/notification.rs
@@ -54,6 +54,20 @@ db_object! {
         pub created_at: i64,
         pub updated_at: i64,
     }
+
+    #[derive(Insertable, Queryable, Selectable, Debug, Clone, Serialize, Deserialize)]
+    #[diesel(table_name = notification_channel_state)]
+    pub struct NotificationChannelState {
+        pub id: i64,
+        pub alert_id: i64,
+        pub alert_fingerprint: String,
+        pub channel_id: i64,
+        pub event_type: String,
+        pub occurrence_key: i64,
+        pub last_notification_at: i64,
+        pub created_at: i64,
+        pub updated_at: i64,
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -217,6 +231,77 @@ pub fn list_channels(include_deleted: bool) -> DbResult<Vec<NotificationChannel>
                 BaseError::DatabaseFatal(Some(format!(
                     "Failed to list notification channels: {}",
                     err
+                )))
+            })
+    })
+}
+
+pub fn get_channel_state(
+    alert_id: i64,
+    channel_id: i64,
+    event_type: &str,
+) -> DbResult<Option<NotificationChannelState>> {
+    let conn = &mut get_connection()?;
+    db_execute!(conn, {
+        notification_channel_state::table
+            .filter(notification_channel_state::dsl::alert_id.eq(alert_id))
+            .filter(notification_channel_state::dsl::channel_id.eq(channel_id))
+            .filter(notification_channel_state::dsl::event_type.eq(event_type))
+            .select(NotificationChannelStateDb::as_select())
+            .first::<NotificationChannelStateDb>(conn)
+            .optional()
+            .map(|row| row.map(NotificationChannelStateDb::from_db))
+            .map_err(|err| {
+                BaseError::DatabaseFatal(Some(format!(
+                    "Failed to get notification channel state alert={} channel={} event={}: {}",
+                    alert_id, channel_id, event_type, err
+                )))
+            })
+    })
+}
+
+pub fn upsert_channel_state(
+    alert_id: i64,
+    alert_fingerprint: &str,
+    channel_id: i64,
+    event_type: &str,
+    occurrence_key: i64,
+    now_ms: i64,
+) -> DbResult<NotificationChannelState> {
+    let conn = &mut get_connection()?;
+    let state = NotificationChannelState {
+        id: ID_GENERATOR.generate_id(),
+        alert_id,
+        alert_fingerprint: alert_fingerprint.to_string(),
+        channel_id,
+        event_type: event_type.to_string(),
+        occurrence_key,
+        last_notification_at: now_ms,
+        created_at: now_ms,
+        updated_at: now_ms,
+    };
+    db_execute!(conn, {
+        diesel::insert_into(notification_channel_state::table)
+            .values(NotificationChannelStateDb::to_db(&state))
+            .on_conflict((
+                notification_channel_state::dsl::alert_id,
+                notification_channel_state::dsl::channel_id,
+                notification_channel_state::dsl::event_type,
+            ))
+            .do_update()
+            .set((
+                notification_channel_state::dsl::alert_fingerprint.eq(alert_fingerprint),
+                notification_channel_state::dsl::occurrence_key.eq(occurrence_key),
+                notification_channel_state::dsl::last_notification_at.eq(now_ms),
+                notification_channel_state::dsl::updated_at.eq(now_ms),
+            ))
+            .returning(NotificationChannelStateDb::as_returning())
+            .get_result::<NotificationChannelStateDb>(conn)
+            .map(NotificationChannelStateDb::from_db)
+            .map_err(|err| {
+                BaseError::DatabaseFatal(Some(format!(
+                    "Failed to upsert notification channel state alert={} channel={} event={}: {}",
+                    alert_id, channel_id, event_type, err
                 )))
             })
     })

--- a/server/src/schema/postgres.rs
+++ b/server/src/schema/postgres.rs
@@ -238,6 +238,22 @@ diesel::table! {
 }
 
 diesel::table! {
+    use diesel::sql_types::{Int8, Text};
+
+    notification_channel_state (id) {
+        id -> Int8,
+        alert_id -> Int8,
+        alert_fingerprint -> Text,
+        channel_id -> Int8,
+        event_type -> Text,
+        occurrence_key -> Int8,
+        last_notification_at -> Int8,
+        created_at -> Int8,
+        updated_at -> Int8,
+    }
+}
+
+diesel::table! {
     use diesel::sql_types::{Int4, Int8, Text, Nullable};
 
     notification_delivery (id) {
@@ -676,6 +692,8 @@ diesel::joinable!(model -> cost_catalogs (cost_catalog_id));
 diesel::joinable!(model -> provider (provider_id));
 diesel::joinable!(model_route_candidate -> model (model_id));
 diesel::joinable!(model_route_candidate -> model_route (route_id));
+diesel::joinable!(notification_channel_state -> alert_event (alert_id));
+diesel::joinable!(notification_channel_state -> notification_channel (channel_id));
 diesel::joinable!(notification_delivery -> alert_event (alert_id));
 diesel::joinable!(notification_delivery -> notification_channel (channel_id));
 diesel::joinable!(provider_api_key -> provider (provider_id));
@@ -717,6 +735,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     model_route,
     model_route_candidate,
     notification_channel,
+    notification_channel_state,
     notification_delivery,
     provider,
     provider_api_key,

--- a/server/src/schema/sqlite.rs
+++ b/server/src/schema/sqlite.rs
@@ -238,6 +238,22 @@ diesel::table! {
 }
 
 diesel::table! {
+    use diesel::sql_types::{BigInt, Text};
+
+    notification_channel_state (id) {
+        id -> BigInt,
+        alert_id -> BigInt,
+        alert_fingerprint -> Text,
+        channel_id -> BigInt,
+        event_type -> Text,
+        occurrence_key -> BigInt,
+        last_notification_at -> BigInt,
+        created_at -> BigInt,
+        updated_at -> BigInt,
+    }
+}
+
+diesel::table! {
     use diesel::sql_types::{BigInt, Integer, Text, Nullable};
 
     notification_delivery (id) {
@@ -676,6 +692,8 @@ diesel::joinable!(model -> cost_catalogs (cost_catalog_id));
 diesel::joinable!(model -> provider (provider_id));
 diesel::joinable!(model_route_candidate -> model (model_id));
 diesel::joinable!(model_route_candidate -> model_route (route_id));
+diesel::joinable!(notification_channel_state -> alert_event (alert_id));
+diesel::joinable!(notification_channel_state -> notification_channel (channel_id));
 diesel::joinable!(notification_delivery -> alert_event (alert_id));
 diesel::joinable!(notification_delivery -> notification_channel (channel_id));
 diesel::joinable!(provider_api_key -> provider (provider_id));
@@ -717,6 +735,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     model_route,
     model_route_candidate,
     notification_channel,
+    notification_channel_state,
     notification_delivery,
     provider,
     provider_api_key,

--- a/server/src/service/alerts/engine.rs
+++ b/server/src/service/alerts/engine.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::controller::BaseError;
 use crate::database::alert::{
-    ALERT_STATUS_ACTIVE, AlertEvent, AlertListFilter, AlertRuleState, get_rule_state, list_alerts,
+    AlertEvent, AlertRuleState, get_rule_state, list_active_alerts_for_evaluation,
 };
 use crate::service::app_state::AppState;
 use crate::service::metrics::MetricsService;
@@ -232,10 +232,7 @@ impl AlertsService {
             summary.fired += 1;
         }
 
-        for alert in list_alerts(AlertListFilter {
-            status: Some(ALERT_STATUS_ACTIVE.to_string()),
-            ..AlertListFilter::default()
-        })? {
+        for alert in list_active_alerts_for_evaluation()? {
             if !managed_rule_key_set.contains(alert.rule_key.as_str()) {
                 continue;
             }
@@ -500,7 +497,9 @@ mod tests {
     use super::*;
     use crate::config::{AlertsConfig, MetricsConfig, ProviderGovernanceConfig};
     use crate::database::TestDbContext;
-    use crate::database::alert::{ALERT_STATUS_RESOLVED, get_alert_by_fingerprint};
+    use crate::database::alert::{
+        ALERT_STATUS_ACTIVE, ALERT_STATUS_RESOLVED, get_alert_by_fingerprint,
+    };
     use crate::database::metrics::{
         MetricAttemptRollupMinute, MetricCostRollupMinute, MetricRequestRollupMinute,
         add_attempt_rollup_delta, add_cost_rollup_delta, add_request_rollup_delta,
@@ -602,6 +601,45 @@ mod tests {
                 .expect("alert should exist");
             assert_eq!(alert.occurrence_count, 2);
             assert_eq!(alert.last_seen_at, 2_000);
+        });
+    }
+
+    #[test]
+    fn engine_resolves_all_active_alerts_beyond_default_page_limit() {
+        let context = TestDbContext::new_sqlite("alert-engine-resolve-all-active.sqlite");
+        context.run_sync(|| {
+            let service = AlertsService::new(AlertsConfig::default());
+            let metrics = MetricsService::new(crate::config::MetricsConfig::default());
+            let candidates = (0..60).map(provider_open_candidate_for).collect::<Vec<_>>();
+
+            let fired = service
+                .apply_rule_candidates(candidates, &["provider_open"], 1_000)
+                .unwrap();
+            assert_eq!(fired.fired, 60);
+
+            let healthy_scopes = (0..60).map(|id| id.to_string()).collect::<HashSet<_>>();
+            let resolved = service
+                .apply_rule_candidates_with_notification(
+                    Vec::new(),
+                    &["provider_open"],
+                    2_000,
+                    None,
+                    0,
+                    &metrics,
+                    None,
+                    Some(&healthy_scopes),
+                )
+                .unwrap();
+            assert_eq!(resolved.resolved, 60);
+
+            for provider_id in 0..60 {
+                let alert =
+                    get_alert_by_fingerprint(&format!("provider_open:provider:{provider_id}"))
+                        .unwrap()
+                        .expect("alert should exist");
+                assert_eq!(alert.status, ALERT_STATUS_RESOLVED);
+                assert_eq!(alert.resolved_at, Some(2_000));
+            }
         });
     }
 
@@ -1130,12 +1168,16 @@ mod tests {
     }
 
     fn provider_open_candidate() -> AlertFireInput {
+        provider_open_candidate_for(7)
+    }
+
+    fn provider_open_candidate_for(provider_id: i64) -> AlertFireInput {
         AlertFireInput {
-            fingerprint: "provider_open:provider:7".to_string(),
+            fingerprint: format!("provider_open:provider:{provider_id}"),
             rule_key: "provider_open".to_string(),
             severity: AlertSeverity::Critical,
             scope_type: AlertScopeType::Provider,
-            scope_id: "7".to_string(),
+            scope_id: provider_id.to_string(),
             title: "Provider open".to_string(),
             summary: "Provider is open".to_string(),
             details_json: "{}".to_string(),

--- a/server/src/service/notification/delivery.rs
+++ b/server/src/service/notification/delivery.rs
@@ -4,8 +4,8 @@ use crate::controller::BaseError;
 use crate::database::alert::{AlertEvent, mark_alert_notified};
 use crate::database::notification::{
     NOTIFICATION_CHANNEL_TYPE_WEBHOOK, NewNotificationDelivery, NotificationChannel,
-    NotificationDelivery, NotificationDeliveryListFilter, enqueue_delivery, list_channels,
-    list_deliveries,
+    NotificationDelivery, NotificationDeliveryListFilter, enqueue_delivery, get_channel_state,
+    list_channels, list_deliveries, upsert_channel_state,
 };
 use crate::service::alerts::lifecycle::is_alert_suppressed;
 
@@ -42,11 +42,7 @@ impl NotificationService {
         let mut enqueued = 0usize;
         for channel in channels {
             if event_type == NotificationEventType::AlertFired
-                && is_fire_cooldown_active(
-                    alert.last_notification_at,
-                    now_ms,
-                    channel.cooldown_seconds.max(0) as u64,
-                )
+                && is_channel_fire_cooldown_active(alert, &channel, now_ms)?
             {
                 continue;
             }
@@ -67,6 +63,16 @@ impl NotificationService {
                 },
                 now_ms,
             )?;
+            if event_type == NotificationEventType::AlertFired {
+                upsert_channel_state(
+                    alert.id,
+                    &alert.fingerprint,
+                    channel.id,
+                    event_type.as_str(),
+                    alert.reopened_count,
+                    now_ms,
+                )?;
+            }
             enqueued += 1;
         }
 
@@ -156,15 +162,40 @@ pub fn delivery_response(delivery: NotificationDelivery) -> NotificationDelivery
     }
 }
 
-fn is_fire_cooldown_active(
-    last_notification_at: Option<i64>,
+fn is_channel_fire_cooldown_active(
+    alert: &AlertEvent,
+    channel: &NotificationChannel,
     now_ms: i64,
-    fire_cooldown_seconds: u64,
-) -> bool {
-    let Some(last_notification_at) = last_notification_at else {
-        return false;
+) -> Result<bool, BaseError> {
+    let Some(state) = get_channel_state(
+        alert.id,
+        channel.id,
+        NotificationEventType::AlertFired.as_str(),
+    )?
+    else {
+        return Ok(alert
+            .last_notification_at
+            .is_some_and(|last_notification_at| {
+                is_fire_cooldown_active(last_notification_at, channel, now_ms)
+            }));
     };
-    let cooldown_ms = (fire_cooldown_seconds as i64).saturating_mul(1_000);
+    if state.occurrence_key != alert.reopened_count {
+        return Ok(false);
+    }
+    Ok(is_fire_cooldown_active(
+        state.last_notification_at,
+        channel,
+        now_ms,
+    ))
+}
+
+fn is_fire_cooldown_active(
+    last_notification_at: i64,
+    channel: &NotificationChannel,
+    now_ms: i64,
+) -> bool {
+    let fire_cooldown_seconds = channel.cooldown_seconds.max(0);
+    let cooldown_ms = fire_cooldown_seconds.saturating_mul(1_000);
     last_notification_at.saturating_add(cooldown_ms) > now_ms
 }
 
@@ -282,7 +313,107 @@ mod tests {
         });
     }
 
+    #[test]
+    fn fire_cooldown_is_tracked_per_channel() {
+        let context = TestDbContext::new_sqlite("notification-delivery-channel-cooldown.sqlite");
+        context.run_sync(|| {
+            let service = NotificationService::new(NotificationConfig::default());
+            let fast = create_enabled_channel_with_cooldown("fast", 1, 900);
+            let slow = create_enabled_channel_with_cooldown("slow", 10, 901);
+            let alert = fire_alert(&sample_fire_record(), 1_000).unwrap();
+
+            let first = service
+                .enqueue_alert_event(&alert, NotificationEventType::AlertFired, 1_000, 60)
+                .unwrap();
+            assert_eq!(first, 2);
+
+            let repeated = fire_alert(&sample_fire_record(), 2_500).unwrap();
+            let second = service
+                .enqueue_alert_event(&repeated, NotificationEventType::AlertFired, 2_500, 60)
+                .unwrap();
+            assert_eq!(second, 1);
+
+            let repeated_again = fire_alert(&sample_fire_record(), 11_500).unwrap();
+            let third = service
+                .enqueue_alert_event(
+                    &repeated_again,
+                    NotificationEventType::AlertFired,
+                    11_500,
+                    60,
+                )
+                .unwrap();
+            assert_eq!(third, 2);
+
+            let deliveries = list_delivery_rows(NotificationDeliveryListFilter {
+                alert_id: Some(alert.id),
+                ..NotificationDeliveryListFilter::default()
+            })
+            .unwrap();
+            assert_eq!(deliveries.len(), 5);
+            assert_eq!(
+                deliveries
+                    .iter()
+                    .filter(|delivery| delivery.channel_id == fast.id)
+                    .count(),
+                3
+            );
+            assert_eq!(
+                deliveries
+                    .iter()
+                    .filter(|delivery| delivery.channel_id == slow.id)
+                    .count(),
+                2
+            );
+        });
+    }
+
+    #[test]
+    fn legacy_alert_notification_timestamp_preserves_cooldown_without_channel_state() {
+        let context = TestDbContext::new_sqlite("notification-delivery-legacy-cooldown.sqlite");
+        context.run_sync(|| {
+            let service = NotificationService::new(NotificationConfig::default());
+            create_enabled_channel_with_cooldown("ops", 10, 900);
+            let alert = fire_alert(&sample_fire_record(), 1_000).unwrap();
+            let legacy_notified = mark_alert_notified(alert.id, 2_000).unwrap();
+
+            let skipped = service
+                .enqueue_alert_event(
+                    &legacy_notified,
+                    NotificationEventType::AlertFired,
+                    11_999,
+                    60,
+                )
+                .unwrap();
+            assert_eq!(skipped, 0);
+
+            let deliveries = list_delivery_rows(NotificationDeliveryListFilter {
+                alert_id: Some(alert.id),
+                ..NotificationDeliveryListFilter::default()
+            })
+            .unwrap();
+            assert!(deliveries.is_empty());
+
+            let expired = service
+                .enqueue_alert_event(
+                    &legacy_notified,
+                    NotificationEventType::AlertFired,
+                    12_000,
+                    60,
+                )
+                .unwrap();
+            assert_eq!(expired, 1);
+        });
+    }
+
     fn create_enabled_channel(channel_key: &str, now_ms: i64) {
+        create_enabled_channel_with_cooldown(channel_key, 900, now_ms);
+    }
+
+    fn create_enabled_channel_with_cooldown(
+        channel_key: &str,
+        cooldown_seconds: i64,
+        now_ms: i64,
+    ) -> crate::database::notification::NotificationChannel {
         crate::database::notification::create_channel(
             &crate::database::notification::NewNotificationChannel {
                 channel_key: channel_key.to_string(),
@@ -291,12 +422,12 @@ mod tests {
                 endpoint_url: "https://example.com/webhook".to_string(),
                 signing_secret: None,
                 headers_json: None,
-                cooldown_seconds: 900,
+                cooldown_seconds,
                 is_enabled: true,
             },
             now_ms,
         )
-        .unwrap();
+        .unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Backfill notification channel state from legacy alert notification timestamps and fall back to legacy cooldown state when an upgraded alert has no per-channel row yet.