### PR TITLE
ci: accelerate workflows and reuse built images

### DIFF
--- a/.github/actions/transform-quality-gate/action.yml
+++ b/.github/actions/transform-quality-gate/action.yml
@@ -1,5 +1,5 @@
 name: Transform Quality Gate
-description: Run the quick transform quality gate and upload its JSON report.
+description: Run the quick transform benchmark and quality gate in one compilation.
 
 runs:
   using: composite
@@ -10,20 +10,40 @@ runs:
         rustup toolchain install stable --profile minimal
         rustup default stable
 
+    - name: Resolve Rust cache key
+      id: rust-cache
+      shell: bash
+      run: echo "version=$(rustc -Vv | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
     - name: Cache cargo artifacts
       uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-transform-${{ hashFiles('**/Cargo.lock') }}
+          target/release
+        key: ${{ runner.os }}-cargo-transform-bench-v3-${{ steps.rust-cache.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-transform-
+          ${{ runner.os }}-cargo-transform-bench-v3-${{ steps.rust-cache.outputs.version }}-
 
-    - name: Run transform quality gate
+    - name: Set up sccache
+      uses: mozilla-actions/sccache-action@v0.0.10
+      with:
+        version: v0.16.0
+
+    - name: Run transform benchmark and quality gate
       shell: bash
-      run: cargo run -p cyder-api --bin transform_quality_gate -- --quick --report-out /tmp/transform-quality-report.json
+      env:
+        CARGO_INCREMENTAL: "0"
+        RUSTC_WRAPPER: sccache
+        SCCACHE_GHA_ENABLED: "true"
+      run: |
+        CYDER_DATA_DIR="${RUNNER_TEMP:-/tmp}/transform-quality-data" \
+          cargo bench --locked -p cyder-api --bench transform_benchmark -- \
+            --quick \
+            --json-out /tmp/transform-benchmark-summary.json \
+            --thresholds "$GITHUB_WORKSPACE/server/src/service/transform/quality/default-thresholds.json" \
+            --quality-report-out /tmp/transform-quality-report.json
 
     - name: Upload transform quality report
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
+      run_backend: ${{ steps.detect.outputs.run_backend }}
+      run_frontend: ${{ steps.detect.outputs.run_frontend }}
       run_transform: ${{ steps.detect.outputs.run_transform }}
       run_docker_smoke: ${{ steps.detect.outputs.run_docker_smoke }}
-      transform_reason: ${{ steps.detect.outputs.transform_reason }}
-      docker_smoke_reason: ${{ steps.detect.outputs.docker_smoke_reason }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,64 +32,93 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
 
+          run_backend=false
+          run_frontend=false
           run_transform=false
           run_docker_smoke=false
-          transform_reason="No transform-sensitive paths changed."
-          docker_smoke_reason="No Docker packaging paths changed."
           changed_files="$(mktemp)"
           : > "$changed_files"
 
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            git diff --name-only "$BASE_SHA" "$HEAD_SHA" > "$changed_files"
+          if [[ "$EVENT_NAME" == "pull_request" || "$EVENT_NAME" == "push" ]]; then
+            if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+              git diff-tree --no-commit-id --name-only -r "$HEAD_SHA" > "$changed_files"
+            else
+              git diff --name-only "$BASE_SHA" "$HEAD_SHA" > "$changed_files"
+            fi
 
             while IFS= read -r file; do
               [[ -z "$file" ]] && continue
 
               case "$file" in
-                Cargo.toml|Cargo.lock|server/*|.github/actions/transform-quality-gate/*|.github/workflows/ci.yml|.github/workflows/master-image.yml|.github/workflows/release.yml)
-                  run_transform=true
-                  transform_reason="Transform-sensitive path changed."
+                Cargo.toml|Cargo.lock|server/*)
+                  run_backend=true
                   ;;
               esac
 
               case "$file" in
-                Dockerfile|.dockerignore|Cargo.lock|Cargo.toml|justfile|server/Cargo.toml|server/src/bin/*|front/package.json|front/package-lock.json|front/tsconfig*.json|front/vite.config.*|.github/workflows/ci.yml|.github/workflows/master-image.yml|.github/workflows/release.yml|.github/actions/*)
+                Cargo.toml|Cargo.lock|server/Cargo.toml|server/benches/transform_benchmark.rs|server/src/bin/transform_quality_gate.rs|server/src/service/transform/*|server/src/schema/enum_def.rs|server/src/cost/*|server/src/utils/mod.rs|server/src/utils/sse.rs|server/src/utils/usage.rs)
+                  run_transform=true
+                  ;;
+              esac
+
+              case "$file" in
+                front/*)
+                  run_frontend=true
+                  ;;
+              esac
+
+              case "$file" in
+                .github/workflows/ci.yml)
+                  run_backend=true
+                  run_frontend=true
+                  run_transform=true
+                  ;;
+              esac
+
+              case "$file" in
+                .github/actions/transform-quality-gate/*)
+                  run_transform=true
+                  ;;
+              esac
+
+              case "$file" in
+                Dockerfile|.dockerignore|docker-entrypoint|Cargo.toml|Cargo.lock|server/Cargo.toml|front/package.json|front/package-lock.json)
                   run_docker_smoke=true
-                  docker_smoke_reason="Docker packaging path changed."
                   ;;
               esac
             done < "$changed_files"
-          elif [[ "$EVENT_NAME" == "push" ]]; then
-            run_transform=true
-            run_docker_smoke=false
-            transform_reason="master push always runs the transform gate."
-            docker_smoke_reason="master push skips Docker smoke because Master Image builds the real edge image after CI passes."
+
+            if [[ "$EVENT_NAME" == "push" ]]; then
+              # Master Image builds the real commit image in parallel with CI.
+              # Repeating the same Docker build here only doubles work.
+              run_docker_smoke=false
+            fi
           else
+            run_backend=true
+            run_frontend=true
             run_transform=true
             run_docker_smoke=true
-            transform_reason="manual dispatch runs the transform gate."
-            docker_smoke_reason="manual dispatch runs Docker smoke."
           fi
 
           {
+            echo "run_backend=$run_backend"
+            echo "run_frontend=$run_frontend"
             echo "run_transform=$run_transform"
             echo "run_docker_smoke=$run_docker_smoke"
-            echo "transform_reason=$transform_reason"
-            echo "docker_smoke_reason=$docker_smoke_reason"
           } >> "$GITHUB_OUTPUT"
 
           {
             echo "### Change Detection"
             echo ""
+            echo "- run_backend: $run_backend"
+            echo "- run_frontend: $run_frontend"
             echo "- run_transform: $run_transform"
             echo "- run_docker_smoke: $run_docker_smoke"
-            echo "- transform_reason: $transform_reason"
-            echo "- docker_smoke_reason: $docker_smoke_reason"
             if [[ -s "$changed_files" ]]; then
               echo ""
               echo "Changed files:"
@@ -113,28 +142,21 @@ jobs:
 
   transform-quality-gate:
     needs: detect-changes
+    if: needs.detect-changes.outputs.run_transform == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - name: Skip transform quality gate
-        if: needs.detect-changes.outputs.run_transform != 'true'
-        shell: bash
-        run: |
-          {
-            echo "### Transform Quality Gate"
-            echo ""
-            echo "Skipped: ${{ needs.detect-changes.outputs.transform_reason }}"
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Checkout repository
-        if: needs.detect-changes.outputs.run_transform == 'true'
         uses: actions/checkout@v4
 
       - name: Run transform quality gate
-        if: needs.detect-changes.outputs.run_transform == 'true'
         uses: ./.github/actions/transform-quality-gate
 
-  backend-static:
+  backend:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.run_backend == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -147,53 +169,40 @@ jobs:
           rustup toolchain install stable --profile minimal --component rustfmt
           rustup default stable
 
+      - name: Resolve Rust cache key
+        id: rust-cache
+        shell: bash
+        run: echo "version=$(rustc -Vv | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
       - name: Cache cargo artifacts
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-backend-static-${{ hashFiles('**/Cargo.lock') }}
+            target/debug
+          key: ${{ runner.os }}-cargo-backend-v4-${{ steps.rust-cache.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-backend-static-
+            ${{ runner.os }}-cargo-backend-v4-${{ steps.rust-cache.outputs.version }}-
 
       - name: Check formatting
         run: cargo fmt --check
 
       - name: Run log lint
-        run: cargo run -p cyder-api --bin log_lint
-
-  backend-tests:
-    runs-on: ubuntu-latest
-    env:
-      CARGO_TERM_COLOR: always
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
         shell: bash
         run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-
-      - name: Cache cargo artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-backend-tests-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-backend-tests-
+          CARGO_MANIFEST_DIR="$GITHUB_WORKSPACE/server" \
+            rustc --edition=2024 server/src/bin/log_lint.rs -o "$RUNNER_TEMP/log_lint"
+          "$RUNNER_TEMP/log_lint"
 
       - name: Run backend tests
-        run: cargo test -p cyder-api
+        run: cargo test --locked -p cyder-api
 
   frontend:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.run_frontend == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: front
@@ -222,33 +231,24 @@ jobs:
 
   docker-smoke:
     needs: detect-changes
+    if: needs.detect-changes.outputs.run_docker_smoke == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - name: Skip Docker smoke
-        if: needs.detect-changes.outputs.run_docker_smoke != 'true'
-        shell: bash
-        run: |
-          {
-            echo "### Docker Smoke"
-            echo ""
-            echo "Skipped: ${{ needs.detect-changes.outputs.docker_smoke_reason }}"
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Checkout repository
-        if: needs.detect-changes.outputs.run_docker_smoke == 'true'
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        if: needs.detect-changes.outputs.run_docker_smoke == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build Docker image
-        if: needs.detect-changes.outputs.run_docker_smoke == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           push: false
           tags: cyder-api:ci-smoke
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=gha,scope=docker-smoke-${{ github.event.pull_request.number || github.ref_name }},version=2
+            type=gha,scope=master-image,version=2
+          cache-to: type=gha,scope=docker-smoke-${{ github.event.pull_request.number || github.ref_name }},mode=max,version=2

--- a/.github/workflows/master-image.yml
+++ b/.github/workflows/master-image.yml
@@ -1,9 +1,7 @@
 name: Master Image
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  push:
     branches: ["master"]
   workflow_dispatch:
     inputs:
@@ -13,47 +11,93 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   packages: write
 
 concurrency:
-  group: master-image-${{ github.event.workflow_run.head_branch || github.ref }}
+  group: master-image-${{ github.event_name == 'push' && github.ref || github.run_id }}
+  # Preserve the commit-addressed image needed by a later release. A docs-only
+  # follow-up push must not cancel an in-flight runtime image build.
   cancel-in-progress: false
 
 jobs:
-  manual-transform-quality-gate:
-    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master')
+  prepare:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      run_build: ${{ steps.detect.outputs.run_build }}
+      build_reason: ${{ steps.detect.outputs.build_reason }}
     steps:
-      - name: Record CI-backed transform gate
-        if: github.event_name == 'workflow_run'
-        shell: bash
-        run: |
-          {
-            echo "### Transform Quality Gate"
-            echo ""
-            echo "Skipped in Master Image because CI already passed for ${{ github.event.workflow_run.head_sha }}."
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Checkout repository
-        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
+          fetch-depth: 0
 
-      - name: Run transform quality gate
-        if: github.event_name == 'workflow_dispatch'
-        uses: ./.github/actions/transform-quality-gate
+      - name: Detect image changes
+        id: detect
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          run_build=false
+          build_reason="No runtime image inputs changed."
+          changed_files="$(mktemp)"
+          : > "$changed_files"
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            run_build=true
+            build_reason="Manual dispatch always builds the requested ref."
+          else
+            if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+              git diff-tree --no-commit-id --name-only -r "$HEAD_SHA" > "$changed_files"
+            else
+              git diff --name-only "$BASE_SHA" "$HEAD_SHA" > "$changed_files"
+            fi
+
+            while IFS= read -r file; do
+              case "$file" in
+                Dockerfile|.dockerignore|docker-entrypoint|Cargo.toml|Cargo.lock|server/*|front/*)
+                  run_build=true
+                  build_reason="Runtime image inputs changed."
+                  break
+                  ;;
+              esac
+            done < "$changed_files"
+          fi
+
+          {
+            echo "run_build=$run_build"
+            echo "build_reason=$build_reason"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Master Image Preparation"
+            echo ""
+            echo "- Build image: ${run_build}"
+            echo "- Reason: ${build_reason}"
+            if [[ -s "$changed_files" ]]; then
+              echo ""
+              echo "Changed files:"
+              sed 's/^/- /' "$changed_files"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
   build-and-push:
-    needs: manual-transform-quality-gate
-    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master')
+    needs: prepare
+    if: needs.prepare.outputs.run_build == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Resolve source metadata
         id: source
@@ -62,7 +106,7 @@ jobs:
           set -euo pipefail
 
           source_sha="$(git rev-parse HEAD)"
-          image="ghcr.io/${GITHUB_REPOSITORY}"
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
 
           {
             echo "source_sha=$source_sha"
@@ -79,32 +123,85 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image
+      - name: Build and push commit image
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: |
-            ${{ steps.source.outputs.image }}:${{ steps.source.outputs.source_sha }}
-            ${{ steps.source.outputs.image }}:edge
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: ${{ steps.source.outputs.image }}:${{ steps.source.outputs.source_sha }}
+          cache-from: type=gha,scope=master-image,version=2
+          cache-to: type=gha,scope=master-image,mode=max,version=2
+
+      - name: Wait for successful CI
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+
+          deadline=$((SECONDS + 1800))
+          while true; do
+            ci_run_tsv="$(
+              gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+                -f head_sha="$SOURCE_SHA" \
+                --jq '.workflow_runs[0] | if . == null then "" else [.id, .status, (.conclusion // "")] | @tsv end'
+            )"
+
+            if [[ -n "$ci_run_tsv" ]]; then
+              IFS=$'\t' read -r ci_run_id ci_status ci_conclusion <<< "$ci_run_tsv"
+              if [[ "$ci_status" == "completed" && "$ci_conclusion" == "success" ]]; then
+                echo "CI run ${ci_run_id} approved image promotion."
+                break
+              fi
+              if [[ "$ci_status" == "completed" ]]; then
+                echo "CI run ${ci_run_id} completed with conclusion ${ci_conclusion}; edge will not move." >&2
+                exit 1
+              fi
+              echo "Waiting for CI run ${ci_run_id}; current status is ${ci_status}."
+            else
+              echo "Waiting for a successful CI run for ${SOURCE_SHA}."
+            fi
+
+            if (( SECONDS >= deadline )); then
+              echo "Timed out waiting for successful CI for ${SOURCE_SHA}." >&2
+              exit 1
+            fi
+            sleep 15
+          done
+
+      - name: Promote commit image to edge
+        shell: bash
+        env:
+          IMAGE: ${{ steps.source.outputs.image }}
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          docker buildx imagetools create \
+            --tag "${IMAGE}:edge" \
+            "${IMAGE}@${BUILD_DIGEST}"
+
+          source_digest="$(docker buildx imagetools inspect "${IMAGE}:${SOURCE_SHA}" --format '{{.Manifest.Digest}}')"
+          edge_digest="$(docker buildx imagetools inspect "${IMAGE}:edge" --format '{{.Manifest.Digest}}')"
+          if [[ "$source_digest" != "$edge_digest" ]]; then
+            echo "Edge digest ${edge_digest} does not match source digest ${source_digest}." >&2
+            exit 1
+          fi
 
       - name: Write image summary
         shell: bash
         env:
-          WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           {
             echo "### Master Image"
             echo ""
-            echo "- Workflow: ${WORKFLOW_NAME}"
             echo "- Run: ${WORKFLOW_RUN_URL}"
             echo "- Source SHA: ${{ steps.source.outputs.source_sha }}"
-            echo "- GHCR image: ${{ steps.source.outputs.image }}"
             echo "- SHA tag: ${{ steps.source.outputs.image }}:${{ steps.source.outputs.source_sha }}"
             echo "- Edge tag: ${{ steps.source.outputs.image }}:edge"
             echo "- Digest: ${{ steps.build.outputs.digest }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,33 +158,26 @@ jobs:
             echo "- Docker Hub image: ${{ steps.validate.outputs.image_dockerhub }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  transform-quality-gate:
+  prepare-version-images:
     needs: validate-release
     runs-on: ubuntu-24.04
+    timeout-minutes: 35
     permissions:
-      contents: read
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.validate-release.outputs.release_tag }}
-
-      - name: Run transform quality gate
-        uses: ./.github/actions/transform-quality-gate
-
-  version-image-preflight:
-    needs: validate-release
-    runs-on: ubuntu-24.04
-    permissions:
-      packages: read
+      packages: write
     outputs:
-      build_version_image: ${{ steps.preflight.outputs.build_version_image }}
-      preflight_reason: ${{ steps.preflight.outputs.preflight_reason }}
+      ghcr_digest_ref: ${{ steps.prepare.outputs.ghcr_digest_ref }}
+      dockerhub_digest_ref: ${{ steps.prepare.outputs.dockerhub_digest_ref }}
     env:
       VERSION: ${{ needs.validate-release.outputs.version }}
+      SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
       IMAGE_GHCR: ${{ needs.validate-release.outputs.image_ghcr }}
       IMAGE_DOCKERHUB: ${{ needs.validate-release.outputs.image_dockerhub }}
     steps:
+      - name: Set up crane
+        uses: imjasonh/setup-crane@v0.7
+        with:
+          version: v0.21.7
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -198,8 +191,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Check immutable version images
-        id: preflight
+      - name: Prepare and verify immutable version images
+        id: prepare
         shell: bash
         run: |
           set -euo pipefail
@@ -207,20 +200,32 @@ jobs:
           ghcr_exists=false
           dockerhub_exists=false
 
-          if docker manifest inspect "${IMAGE_GHCR}:${VERSION}" >/dev/null 2>&1; then
+          if crane digest "${IMAGE_GHCR}:${VERSION}" >/dev/null 2>&1; then
             ghcr_exists=true
           fi
 
-          if docker manifest inspect "${IMAGE_DOCKERHUB}:${VERSION}" >/dev/null 2>&1; then
+          if crane digest "${IMAGE_DOCKERHUB}:${VERSION}" >/dev/null 2>&1; then
             dockerhub_exists=true
           fi
 
           if [[ "$ghcr_exists" == "true" && "$dockerhub_exists" == "true" ]]; then
-            build_version_image=false
-            preflight_reason="Both immutable version images already exist; release will reuse and verify them."
+            prepare_reason="Both immutable version images already exist; reusing them."
           elif [[ "$ghcr_exists" == "false" && "$dockerhub_exists" == "false" ]]; then
-            build_version_image=true
-            preflight_reason="No immutable version images exist; release will build and push them."
+            source_ref="${IMAGE_GHCR}:${SOURCE_SHA}"
+            deadline=$((SECONDS + 1800))
+            while ! source_digest="$(crane digest "$source_ref" 2>/dev/null)"; do
+              if (( SECONDS >= deadline )); then
+                echo "Timed out waiting for Master Image artifact ${source_ref}." >&2
+                exit 1
+              fi
+              echo "Waiting for Master Image artifact ${source_ref}."
+              sleep 15
+            done
+
+            source_digest_ref="${IMAGE_GHCR}@${source_digest}"
+            crane copy "$source_digest_ref" "${IMAGE_GHCR}:${VERSION}"
+            crane copy "$source_digest_ref" "${IMAGE_DOCKERHUB}:${VERSION}"
+            prepare_reason="Promoted the CI-approved commit image to immutable version tags without rebuilding it."
           else
             echo "Immutable version image state is inconsistent." >&2
             echo "GHCR ${IMAGE_GHCR}:${VERSION} exists: ${ghcr_exists}" >&2
@@ -229,131 +234,15 @@ jobs:
             exit 1
           fi
 
-          {
-            echo "build_version_image=$build_version_image"
-            echo "preflight_reason=$preflight_reason"
-          } >> "$GITHUB_OUTPUT"
+          ghcr_digest="$(crane digest "${IMAGE_GHCR}:${VERSION}")"
+          dockerhub_digest="$(crane digest "${IMAGE_DOCKERHUB}:${VERSION}")"
+          if [[ "$ghcr_digest" != "$dockerhub_digest" ]]; then
+            echo "Registry digests differ for immutable version ${VERSION}." >&2
+            echo "GHCR: ${ghcr_digest}" >&2
+            echo "Docker Hub: ${dockerhub_digest}" >&2
+            exit 1
+          fi
 
-          {
-            echo "### Version Image Preflight"
-            echo ""
-            echo "- GHCR ${IMAGE_GHCR}:${VERSION} exists: ${ghcr_exists}"
-            echo "- Docker Hub ${IMAGE_DOCKERHUB}:${VERSION} exists: ${dockerhub_exists}"
-            echo "- Build version image: ${build_version_image}"
-            echo "- Reason: ${preflight_reason}"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  build-version-image:
-    needs:
-      - validate-release
-      - transform-quality-gate
-      - version-image-preflight
-    if: needs.version-image-preflight.outputs.build_version_image == 'true'
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      packages: write
-    env:
-      IMAGE_DOCKERHUB: ${{ needs.validate-release.outputs.image_dockerhub }}
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.validate-release.outputs.release_tag }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push immutable release image
-        id: build
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: |
-            ${{ needs.validate-release.outputs.image_ghcr }}:${{ needs.validate-release.outputs.version }}
-            ${{ env.IMAGE_DOCKERHUB }}:${{ needs.validate-release.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Write image summary
-        shell: bash
-        env:
-          WORKFLOW_NAME: ${{ github.workflow }}
-          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          {
-            echo "### Release Image"
-            echo ""
-            echo "- Workflow: ${WORKFLOW_NAME}"
-            echo "- Run: ${WORKFLOW_RUN_URL}"
-            echo "- Release tag: ${{ needs.validate-release.outputs.release_tag }}"
-            echo "- Version: ${{ needs.validate-release.outputs.version }}"
-            echo "- Source SHA: ${{ needs.validate-release.outputs.source_sha }}"
-            echo "- GHCR version tag: ${{ needs.validate-release.outputs.image_ghcr }}:${{ needs.validate-release.outputs.version }}"
-            echo "- Docker Hub version tag: ${IMAGE_DOCKERHUB}:${{ needs.validate-release.outputs.version }}"
-            echo "- Build digest: ${{ steps.build.outputs.digest }}"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  verify-version-images:
-    needs:
-      - validate-release
-      - transform-quality-gate
-      - version-image-preflight
-      - build-version-image
-    if: always() && needs.validate-release.result == 'success' && needs.transform-quality-gate.result == 'success' && needs.version-image-preflight.result == 'success' && (needs.build-version-image.result == 'success' || needs.build-version-image.result == 'skipped')
-    runs-on: ubuntu-24.04
-    permissions:
-      packages: read
-    outputs:
-      ghcr_digest_ref: ${{ steps.verify.outputs.ghcr_digest_ref }}
-      dockerhub_digest_ref: ${{ steps.verify.outputs.dockerhub_digest_ref }}
-    env:
-      VERSION: ${{ needs.validate-release.outputs.version }}
-      IMAGE_GHCR: ${{ needs.validate-release.outputs.image_ghcr }}
-      IMAGE_DOCKERHUB: ${{ needs.validate-release.outputs.image_dockerhub }}
-    steps:
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Verify immutable version images
-        id: verify
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          docker pull "${IMAGE_GHCR}:${VERSION}"
-          docker pull "${IMAGE_DOCKERHUB}:${VERSION}"
-
-          ghcr_digest="$(docker buildx imagetools inspect "${IMAGE_GHCR}:${VERSION}" --format '{{.Manifest.Digest}}')"
-          dockerhub_digest="$(docker buildx imagetools inspect "${IMAGE_DOCKERHUB}:${VERSION}" --format '{{.Manifest.Digest}}')"
           ghcr_digest_ref="${IMAGE_GHCR}@${ghcr_digest}"
           dockerhub_digest_ref="${IMAGE_DOCKERHUB}@${dockerhub_digest}"
 
@@ -363,18 +252,19 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           {
-            echo "### Release Image Verification"
+            echo "### Immutable Version Images"
             echo ""
-            echo "- Verified GHCR version image: ${IMAGE_GHCR}:${VERSION}"
+            echo "- GHCR ${IMAGE_GHCR}:${VERSION} exists: ${ghcr_exists}"
+            echo "- Docker Hub ${IMAGE_DOCKERHUB}:${VERSION} exists: ${dockerhub_exists}"
             echo "- GHCR digest ref: ${ghcr_digest_ref}"
-            echo "- Verified Docker Hub version image: ${IMAGE_DOCKERHUB}:${VERSION}"
             echo "- Docker Hub digest ref: ${dockerhub_digest_ref}"
+            echo "- Result: ${prepare_reason}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   create-draft-release:
     needs:
       - validate-release
-      - verify-version-images
+      - prepare-version-images
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -385,8 +275,8 @@ jobs:
       IMAGE_DOCKERHUB: ${{ needs.validate-release.outputs.image_dockerhub }}
       SOURCE_SHA: ${{ needs.validate-release.outputs.source_sha }}
       CI_RUN_ID: ${{ needs.validate-release.outputs.ci_run_id }}
-      GHCR_DIGEST_REF: ${{ needs.verify-version-images.outputs.ghcr_digest_ref }}
-      DOCKERHUB_DIGEST_REF: ${{ needs.verify-version-images.outputs.dockerhub_digest_ref }}
+      GHCR_DIGEST_REF: ${{ needs.prepare-version-images.outputs.ghcr_digest_ref }}
+      DOCKERHUB_DIGEST_REF: ${{ needs.prepare-version-images.outputs.dockerhub_digest_ref }}
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
     steps:
@@ -470,6 +360,7 @@ jobs:
       - validate-release
       - create-draft-release
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     environment: release
     permissions:
       contents: write
@@ -483,6 +374,11 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
     steps:
+      - name: Set up crane
+        uses: imjasonh/setup-crane@v0.7
+        with:
+          version: v0.21.7
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -496,38 +392,35 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull immutable version images
+      - name: Promote and verify release image tags
         shell: bash
         run: |
           set -euo pipefail
 
-          docker pull "${IMAGE_GHCR}:${VERSION}"
-          docker pull "${IMAGE_DOCKERHUB}:${VERSION}"
+          ghcr_digest="$(crane digest "${IMAGE_GHCR}:${VERSION}")"
+          dockerhub_digest="$(crane digest "${IMAGE_DOCKERHUB}:${VERSION}")"
 
-      - name: Promote release image tags
-        shell: bash
-        run: |
-          set -euo pipefail
+          crane tag "${IMAGE_GHCR}:${VERSION}" "$MAJOR_MINOR"
+          crane tag "${IMAGE_GHCR}:${VERSION}" latest
+          crane tag "${IMAGE_DOCKERHUB}:${VERSION}" "$MAJOR_MINOR"
+          crane tag "${IMAGE_DOCKERHUB}:${VERSION}" latest
 
-          docker tag "${IMAGE_GHCR}:${VERSION}" "${IMAGE_GHCR}:${MAJOR_MINOR}"
-          docker tag "${IMAGE_GHCR}:${VERSION}" "${IMAGE_GHCR}:latest"
-          docker tag "${IMAGE_DOCKERHUB}:${VERSION}" "${IMAGE_DOCKERHUB}:${MAJOR_MINOR}"
-          docker tag "${IMAGE_DOCKERHUB}:${VERSION}" "${IMAGE_DOCKERHUB}:latest"
+          verify_tag() {
+            local image="$1"
+            local tag="$2"
+            local expected_digest="$3"
+            local actual_digest
+            actual_digest="$(crane digest "${image}:${tag}")"
+            if [[ "$actual_digest" != "$expected_digest" ]]; then
+              echo "${image}:${tag} digest ${actual_digest} does not match ${expected_digest}." >&2
+              exit 1
+            fi
+          }
 
-          docker push "${IMAGE_GHCR}:${MAJOR_MINOR}"
-          docker push "${IMAGE_GHCR}:latest"
-          docker push "${IMAGE_DOCKERHUB}:${MAJOR_MINOR}"
-          docker push "${IMAGE_DOCKERHUB}:latest"
-
-      - name: Verify promoted tags
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          docker pull "${IMAGE_GHCR}:${MAJOR_MINOR}"
-          docker pull "${IMAGE_GHCR}:latest"
-          docker pull "${IMAGE_DOCKERHUB}:${MAJOR_MINOR}"
-          docker pull "${IMAGE_DOCKERHUB}:latest"
+          verify_tag "$IMAGE_GHCR" "$MAJOR_MINOR" "$ghcr_digest"
+          verify_tag "$IMAGE_GHCR" latest "$ghcr_digest"
+          verify_tag "$IMAGE_DOCKERHUB" "$MAJOR_MINOR" "$dockerhub_digest"
+          verify_tag "$IMAGE_DOCKERHUB" latest "$dockerhub_digest"
 
           {
             echo "### Release Promotion Verification"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,36 @@
-# Stage 1: Use the base image and install cargo-chef
 # 1.93.0-24.13.0-alpine3.23
-FROM cyderhub/cyder-api-base@sha256:4c7089fa3bb10a31405f4dbb7773e54b4f37f3d4261afedc8487f013dd88a144 AS chef
-RUN cargo install cargo-chef --locked
+FROM cyderhub/cyder-api-base@sha256:4c7089fa3bb10a31405f4dbb7773e54b4f37f3d4261afedc8487f013dd88a144 AS base
 WORKDIR /work
 
-# Stage 2: Plan Rust dependencies
+# Rust dependency planner and builder.
+FROM base AS chef
+RUN cargo install cargo-chef --locked
+
 FROM chef AS planner
-COPY . .
+COPY Cargo.toml Cargo.lock ./
+COPY server ./server
 RUN cargo chef prepare --recipe-path recipe.json
 
-# Stage 3: Build Rust dependencies and business logic
-FROM chef AS builder
+FROM chef AS rust-builder
 COPY --from=planner /work/recipe.json recipe.json
-# Build Rust dependencies (cached layer)
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
-RUN cargo chef cook --release --all-targets --recipe-path recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 
-# Install frontend dependencies in their own cacheable layer.
+COPY Cargo.toml Cargo.lock ./
+COPY server ./server
+RUN cargo build --locked -p cyder-api --release --bin cyder-api
+RUN mkdir -p /opt/cyder/bin && \
+    cp /work/target/release/cyder-api /opt/cyder/bin/cyder-api
+
+# Build the frontend independently so frontend-only changes do not invalidate
+# the Rust binary layer, and backend-only changes keep the frontend layer hot.
+FROM base AS frontend-builder
 COPY front/package.json front/package-lock.json front/
 RUN npm --prefix front ci
-
-# Copy the remaining project source. .dockerignore excludes build outputs and deps.
-COPY . .
-
+COPY front ./front
 RUN npm --prefix front run build
-RUN cargo build -p cyder-api --release
 
-# Prepare final artifacts
-RUN mkdir -p /opt/cyder/bin && \
-    cp /work/target/release/cyder-api /opt/cyder/bin/cyder-api && \
-    cp -r /work/front/dist /opt/cyder/public
-
-# Stage 4: Final runtime image
+# Final runtime image.
 FROM alpine:3.21.3
 
 RUN apk add --no-cache ca-certificates su-exec && \
@@ -46,7 +45,8 @@ RUN apk add --no-cache ca-certificates su-exec && \
         /tmp/cyder-api && \
     chown -R cyder:cyder /data/cyder /tmp/cyder-api
 
-COPY --from=builder /opt/cyder /opt/cyder/
+COPY --from=rust-builder /opt/cyder/bin /opt/cyder/bin/
+COPY --from=frontend-builder /work/front/dist /opt/cyder/public/
 COPY docker-entrypoint /usr/local/bin/cyder-entrypoint
 RUN chmod 0755 /usr/local/bin/cyder-entrypoint && \
     chmod -R a+rX /opt/cyder

--- a/server/benches/transform_benchmark.rs
+++ b/server/benches/transform_benchmark.rs
@@ -1,10 +1,15 @@
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use cyder_api::schema::enum_def::LlmApiType;
-use cyder_api::service::transform::quality::{BenchmarkScenarioMetrics, BenchmarkSummary};
+use cyder_api::service::transform::quality::{
+    BenchmarkScenarioMetrics, BenchmarkSummary, TransformQualityReport,
+    build_transform_quality_report, load_benchmark_thresholds, write_transform_quality_report,
+};
 use cyder_api::service::transform::{StreamTransformer, transform_request_data, transform_result};
 use cyder_api::utils::sse::SseEvent;
 use serde::{Deserialize, Serialize};
@@ -189,13 +194,29 @@ struct ScenarioResult {
     avg_peak_bytes: f64,
 }
 
-fn main() {
+struct BenchmarkArgs {
+    quick: bool,
+    json_out: Option<PathBuf>,
+    thresholds: Option<PathBuf>,
+    quality_report_out: Option<PathBuf>,
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::from(1),
+        Err(err) => {
+            eprintln!("transform benchmark failed: {err}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run() -> Result<bool, String> {
     let scenarios = build_scenarios();
-    let args: Vec<String> = std::env::args().collect();
-    let quick = args.iter().any(|arg| arg == "--quick");
-    let json_out = arg_value(&args, "--json-out");
-    let warmup_rounds = if quick { 2 } else { 5 };
-    let sample_rounds = if quick { 8 } else { 24 };
+    let args = parse_args(std::env::args().skip(1).collect())?;
+    let warmup_rounds = if args.quick { 2 } else { 5 };
+    let sample_rounds = if args.quick { 8 } else { 24 };
     let mut summary_results = Vec::with_capacity(scenarios.len());
 
     println!(
@@ -245,25 +266,119 @@ fn main() {
         );
     }
 
-    if let Some(path) = json_out {
-        let summary = BenchmarkSummary {
-            format_version: 1,
-            quick,
-            warmup_rounds,
-            sample_rounds,
-            scenarios: summary_results,
-        };
-        let payload =
-            serde_json::to_vec_pretty(&summary).expect("serialize transform benchmark summary");
-        std::fs::write(&path, payload).expect("write transform benchmark summary");
-        eprintln!("Wrote transform benchmark summary to {}", path);
+    let summary = BenchmarkSummary {
+        format_version: 1,
+        quick: args.quick,
+        warmup_rounds,
+        sample_rounds,
+        scenarios: summary_results,
+    };
+
+    if let Some(path) = &args.json_out {
+        write_json(path, &summary, "transform benchmark summary")?;
+        eprintln!("Wrote transform benchmark summary to {}", path.display());
     }
+
+    let Some(report_out) = &args.quality_report_out else {
+        return Ok(true);
+    };
+    let thresholds_path = args
+        .thresholds
+        .as_deref()
+        .ok_or_else(|| "--quality-report-out requires --thresholds".to_string())?;
+    let thresholds = load_benchmark_thresholds(thresholds_path)?;
+    let report = build_transform_quality_report(summary, &thresholds);
+    write_transform_quality_report(report_out, &report)?;
+    eprintln!("Wrote transform quality report to {}", report_out.display());
+    print_report_summary(&report);
+
+    Ok(report.passed)
 }
 
-fn arg_value(args: &[String], flag: &str) -> Option<String> {
-    args.windows(2)
-        .find(|window| window[0] == flag)
-        .map(|window| window[1].clone())
+fn parse_args(args: Vec<String>) -> Result<BenchmarkArgs, String> {
+    let mut quick = false;
+    let mut json_out = None;
+    let mut thresholds = None;
+    let mut quality_report_out = None;
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--quick" => {
+                quick = true;
+                index += 1;
+            }
+            // Cargo appends this marker when executing a harness-free bench target.
+            "--bench" => {
+                index += 1;
+            }
+            "--json-out" => {
+                json_out = Some(parse_path_arg(&args, index, "--json-out")?);
+                index += 2;
+            }
+            "--thresholds" => {
+                thresholds = Some(parse_path_arg(&args, index, "--thresholds")?);
+                index += 2;
+            }
+            "--quality-report-out" => {
+                quality_report_out = Some(parse_path_arg(&args, index, "--quality-report-out")?);
+                index += 2;
+            }
+            other => return Err(format!("unsupported argument: {other}")),
+        }
+    }
+
+    if thresholds.is_some() != quality_report_out.is_some() {
+        return Err("--thresholds and --quality-report-out must be used together".to_string());
+    }
+
+    Ok(BenchmarkArgs {
+        quick,
+        json_out,
+        thresholds,
+        quality_report_out,
+    })
+}
+
+fn parse_path_arg(args: &[String], index: usize, flag: &str) -> Result<PathBuf, String> {
+    args.get(index + 1)
+        .map(PathBuf::from)
+        .ok_or_else(|| format!("{flag} requires a path"))
+}
+
+fn write_json(path: &Path, value: &impl Serialize, label: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("create {label} directory {}: {err}", parent.display()))?;
+    }
+    let payload =
+        serde_json::to_vec_pretty(value).map_err(|err| format!("serialize {label}: {err}"))?;
+    std::fs::write(path, payload).map_err(|err| format!("write {label} {}: {err}", path.display()))
+}
+
+fn print_report_summary(report: &TransformQualityReport) {
+    let passed_checks = report
+        .threshold_checks
+        .iter()
+        .filter(|check| check.passed)
+        .count();
+    eprintln!(
+        "Transform quality gate: replay_passed={}, benchmark_checks={}/{}",
+        report.replay_summary.passed,
+        passed_checks,
+        report.threshold_checks.len()
+    );
+
+    for check in report.threshold_checks.iter().filter(|check| !check.passed) {
+        eprintln!(
+            "benchmark regression: {}/{} -> {}",
+            check.kind,
+            check.scenario,
+            check.failures.join("; ")
+        );
+    }
 }
 
 fn run_scenario(scenario: &Scenario, warmup_rounds: usize, sample_rounds: usize) -> ScenarioResult {

--- a/server/src/service/transform/quality/mod.rs
+++ b/server/src/service/transform/quality/mod.rs
@@ -11,7 +11,10 @@ pub use replay::{
     ReplayRegressionReport, ReplayRegressionSummary, SemanticReplaySnapshot, SemanticToolCall,
     build_stage2_replay_regression_summary,
 };
-pub use report::{TransformQualityReport, build_transform_quality_report};
+pub use report::{
+    TransformQualityReport, build_transform_quality_report, load_benchmark_thresholds,
+    write_transform_quality_report,
+};
 pub use thresholds::{
     BenchmarkThresholdCheck, BenchmarkThresholdRule, BenchmarkThresholds,
     evaluate_benchmark_thresholds,

--- a/server/src/service/transform/quality/report.rs
+++ b/server/src/service/transform/quality/report.rs
@@ -1,3 +1,6 @@
+use std::fs;
+use std::path::Path;
+
 use serde::{Deserialize, Serialize};
 
 use super::benchmark::BenchmarkSummary;
@@ -31,4 +34,26 @@ pub fn build_transform_quality_report(
         threshold_checks,
         passed,
     }
+}
+
+pub fn load_benchmark_thresholds(path: &Path) -> Result<BenchmarkThresholds, String> {
+    let payload =
+        fs::read(path).map_err(|err| format!("read thresholds {}: {err}", path.display()))?;
+    serde_json::from_slice(&payload)
+        .map_err(|err| format!("parse thresholds {}: {err}", path.display()))
+}
+
+pub fn write_transform_quality_report(
+    path: &Path,
+    report: &TransformQualityReport,
+) -> Result<(), String> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("create report directory {}: {err}", parent.display()))?;
+    }
+    let payload = serde_json::to_vec_pretty(report)
+        .map_err(|err| format!("serialize transform quality report: {err}"))?;
+    fs::write(path, payload).map_err(|err| format!("write report {}: {err}", path.display()))
 }

--- a/server/src/service/transform/quality/tests.rs
+++ b/server/src/service/transform/quality/tests.rs
@@ -199,3 +199,43 @@ fn test_benchmark_threshold_evaluation_reports_regressions() {
     assert!(!checks[0].passed);
     assert_eq!(checks[0].failures.len(), 6);
 }
+
+#[test]
+fn test_quality_report_file_helpers_round_trip_gate_artifacts() {
+    let temp_dir = tempfile::tempdir().expect("quality gate temp dir");
+    let thresholds_path = temp_dir.path().join("thresholds.json");
+    let report_path = temp_dir.path().join("artifacts/quality-report.json");
+    let thresholds = BenchmarkThresholds {
+        format_version: 1,
+        quick: true,
+        require_native_schema_conformance: true,
+        checks: Vec::new(),
+    };
+    std::fs::write(
+        &thresholds_path,
+        serde_json::to_vec_pretty(&thresholds).expect("serialize thresholds"),
+    )
+    .expect("write thresholds");
+
+    let loaded = load_benchmark_thresholds(&thresholds_path).expect("load thresholds");
+    assert_eq!(loaded, thresholds);
+
+    let report = build_transform_quality_report(
+        BenchmarkSummary {
+            format_version: 1,
+            quick: true,
+            warmup_rounds: 2,
+            sample_rounds: 8,
+            scenarios: Vec::new(),
+        },
+        &loaded,
+    );
+    assert!(report.passed);
+
+    write_transform_quality_report(&report_path, &report).expect("write quality report");
+    let persisted: TransformQualityReport = serde_json::from_slice(
+        &std::fs::read(&report_path).expect("read persisted quality report"),
+    )
+    .expect("parse persisted quality report");
+    assert_eq!(persisted, report);
+}


### PR DESCRIPTION
## Summary

- select backend, frontend, transform, and Docker jobs from changed paths
- collapse transform benchmarking and quality evaluation into one compilation
- improve Cargo, sccache, npm, and BuildKit cache reuse
- build master images in parallel with CI and promote edge only after same-SHA CI succeeds
- reuse immutable SHA images for releases instead of rebuilding them

## Real GitHub Actions benchmark

- controlled cold baseline: 25:17
- optimized cold run: 23:07, 8.6% faster
- controlled hot baseline: 7:19
- optimized hot runs: 3:10 and 2:30, average 2:50 and 61.3% faster
- transform gate hot path: 7:03 down to 45-58 seconds

Cold run: https://github.com/cyder-hub/cyder-api/actions/runs/29405832884
Hot run 1: https://github.com/cyder-hub/cyder-api/actions/runs/29407310950
Hot run 2: https://github.com/cyder-hub/cyder-api/actions/runs/29407630113

## Verification

- cargo fmt --check
- actionlint
- cargo test --locked -p cyder-api: 1153 tests passed on current master baseline
- real cold and repeated hot GitHub Actions runs completed successfully

The master-image and release publishing paths were not used to move production tags during benchmarking; their Docker build path was exercised through docker-smoke.