### PR TITLE
fix(proxy): harden last-candidate recovery diagnostics

### DIFF
--- a/server/src/proxy/integration.rs
+++ b/server/src/proxy/integration.rs
@@ -4,6 +4,7 @@ use crate::{
     database::{
         TestDbContext,
         api_key::{ApiKey, CreateApiKeyPayload, UpdateApiKeyMetadataPayload},
+        api_key_acl_rule::ApiKeyAclRuleInput,
         model::Model,
         model_route::{CreateModelRoutePayload, ModelRoute, ModelRouteCandidateInput},
         provider::{BootstrapProviderInput, Provider, ProviderApiKey},
@@ -14,7 +15,7 @@ use crate::{
     schema::enum_def::{
         Action, LlmApiType, ProviderApiKeyMode, ProviderType, RequestAttemptStatus,
         RequestPatchOperation, RequestPatchPlacement, RequestReplayMode, RequestReplayStatus,
-        RequestStatus, SchedulerAction,
+        RequestStatus, RuleScope, SchedulerAction,
     },
     service::{
         app_state::{AppState, create_test_app_state},
@@ -323,9 +324,57 @@ impl TestFixture {
         api_key_default_action: Option<Action>,
         real_model_name: Option<String>,
     ) -> Self {
+        Self::new_with_acl_policy(
+            test_db_context,
+            provider_type,
+            endpoint,
+            api_key_default_action,
+            real_model_name,
+            false,
+        )
+        .await
+    }
+
+    async fn new_allowing_only_primary_model(
+        test_db_context: TestDbContext,
+        provider_type: ProviderType,
+        endpoint: String,
+        real_model_name: Option<String>,
+    ) -> Self {
+        Self::new_with_acl_policy(
+            test_db_context,
+            provider_type,
+            endpoint,
+            Some(Action::Deny),
+            real_model_name,
+            true,
+        )
+        .await
+    }
+
+    async fn new_with_acl_policy(
+        test_db_context: TestDbContext,
+        provider_type: ProviderType,
+        endpoint: String,
+        api_key_default_action: Option<Action>,
+        real_model_name: Option<String>,
+        allow_only_primary_model: bool,
+    ) -> Self {
         let (provider, provider_api_key, model) =
             create_provider_model(provider_type, endpoint, real_model_name);
         let api_key_nonce = ID_GENERATOR.generate_id();
+        let acl_rules = allow_only_primary_model.then(|| {
+            vec![ApiKeyAclRuleInput {
+                id: None,
+                effect: Action::Allow,
+                scope: RuleScope::Model,
+                provider_id: Some(provider.id),
+                model_id: Some(model.id),
+                priority: 100,
+                is_enabled: Some(true),
+                description: Some("allow only the primary integration model".to_string()),
+            }]
+        });
         let created_api_key = ApiKey::create(&CreateApiKeyPayload {
             name: format!("proxy-int-api-key-{api_key_nonce}"),
             description: Some("proxy integration test".to_string()),
@@ -341,7 +390,7 @@ impl TestFixture {
             budget_daily_currency: None,
             budget_monthly_nanos: None,
             budget_monthly_currency: None,
-            acl_rules: None,
+            acl_rules,
         })
         .expect("api key should be created");
         let api_key = TestApiKey {
@@ -2545,6 +2594,372 @@ fn provider_governance_open_candidate_is_skipped_and_falls_back_without_upstream
 }
 
 #[test]
+fn provider_governance_open_candidate_executes_when_next_route_candidate_is_acl_denied() {
+    run_integration_test(|test_db_context| async move {
+        if !CONFIG.provider_governance.is_enabled() {
+            eprintln!("skipping provider governance ACL fallback scenario: governance disabled");
+            return;
+        }
+
+        let Some(primary_upstream) = spawn_test_upstream_or_skip(|request| {
+            assert_eq!(request.path, "/v1/chat/completions");
+            UpstreamReply::json(
+                StatusCode::OK,
+                json!({
+                    "id": "chatcmpl-open-primary",
+                    "object": "chat.completion",
+                    "model": "open-primary-model",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "primary ok"},
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {
+                        "prompt_tokens": 3,
+                        "completion_tokens": 2,
+                        "total_tokens": 5
+                    }
+                }),
+            )
+        })
+        .await
+        else {
+            return;
+        };
+        let Some(denied_upstream) = spawn_test_upstream_or_skip(|_| {
+            panic!("ACL-denied fallback provider should not be called");
+        })
+        .await
+        else {
+            return;
+        };
+
+        let fixture = TestFixture::new_allowing_only_primary_model(
+            test_db_context.clone(),
+            ProviderType::Openai,
+            format!("{}/v1", primary_upstream.base_url),
+            Some("open-primary-model".to_string()),
+        )
+        .await;
+        let (denied_provider, denied_key, denied_model) = create_provider_model(
+            ProviderType::Openai,
+            format!("{}/v1", denied_upstream.base_url),
+            Some("denied-fallback-model".to_string()),
+        );
+        let route_name = format!(
+            "proxy-int-governance-acl-route-{}",
+            ID_GENERATOR.generate_id()
+        );
+        let route = ModelRoute::create(&CreateModelRoutePayload {
+            route_name: route_name.clone(),
+            description: Some("provider governance ACL fallback integration test".to_string()),
+            is_enabled: Some(true),
+            expose_in_models: Some(true),
+            candidates: vec![
+                ModelRouteCandidateInput {
+                    model_id: fixture.model.id,
+                    priority: 0,
+                    is_enabled: Some(true),
+                },
+                ModelRouteCandidateInput {
+                    model_id: denied_model.id,
+                    priority: 1,
+                    is_enabled: Some(true),
+                },
+            ],
+        })
+        .expect("model route should be created");
+        fixture.app_state.catalog.reload().await;
+
+        for _ in 0..CONFIG
+            .provider_governance
+            .consecutive_failure_threshold
+            .max(1)
+        {
+            fixture
+                .app_state
+                .provider_circuit
+                .record_provider_failure(
+                    fixture.provider.id,
+                    "forced test failure".to_string(),
+                    None,
+                )
+                .await
+                .expect("forced provider failure should be recorded");
+        }
+
+        let request = build_json_request(
+            "/openai/v1/chat/completions",
+            &[(
+                "authorization",
+                format!("Bearer {}", fixture.api_key.api_key),
+            )],
+            json!({
+                "model": route_name,
+                "messages": [{"role": "user", "content": "hi"}]
+            }),
+        );
+        let response = fixture.send(request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value =
+            serde_json::from_slice(&response_body_bytes(response).await).expect("proxy body json");
+        assert_eq!(body["choices"][0]["message"]["content"], "primary ok");
+        assert_eq!(primary_upstream.captured_requests().await.len(), 1);
+        assert_eq!(denied_upstream.captured_requests().await.len(), 0);
+
+        let snapshot = fixture
+            .app_state
+            .provider_circuit
+            .get_provider_health_snapshot(fixture.provider.id)
+            .await
+            .expect("provider health snapshot should load");
+        assert_eq!(snapshot.status, ProviderHealthStatus::Healthy);
+
+        let log = fixture.latest_log().await;
+        assert_eq!(log.overall_status, RequestStatus::Success);
+        assert_eq!(log.attempt_count, 1);
+        assert_eq!(log.fallback_count, 0);
+        assert_eq!(log.final_provider_id, Some(fixture.provider.id));
+
+        let attempts = fixture.attempts_for_log(log.id).await;
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(attempts[0].attempt_status, RequestAttemptStatus::Success);
+        assert_eq!(attempts[0].scheduler_action, SchedulerAction::ReturnSuccess);
+
+        let _ = ModelRoute::delete(route.route.id);
+        let _ = Model::delete(denied_model.id);
+        let _ = ProviderApiKey::delete(denied_key.id);
+        let _ = Provider::delete(denied_provider.id);
+        fixture.cleanup().await;
+    });
+}
+
+#[test]
+fn provider_governance_open_direct_candidate_executes_when_no_fallback_exists() {
+    run_integration_test(|test_db_context| async move {
+        if !CONFIG.provider_governance.is_enabled() {
+            eprintln!("skipping provider governance direct scenario: governance disabled");
+            return;
+        }
+
+        let Some(upstream) = spawn_test_upstream_or_skip(|request| {
+            assert_eq!(request.path, "/v1/chat/completions");
+            UpstreamReply::json(
+                StatusCode::OK,
+                json!({
+                    "id": "chatcmpl-direct-open",
+                    "object": "chat.completion",
+                    "model": "direct-open-model",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "direct ok"},
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {
+                        "prompt_tokens": 3,
+                        "completion_tokens": 2,
+                        "total_tokens": 5
+                    }
+                }),
+            )
+        })
+        .await
+        else {
+            return;
+        };
+
+        let fixture = TestFixture::new(
+            test_db_context.clone(),
+            ProviderType::Openai,
+            format!("{}/v1", upstream.base_url),
+            None,
+            Some("direct-open-model".to_string()),
+        )
+        .await;
+
+        for _ in 0..CONFIG
+            .provider_governance
+            .consecutive_failure_threshold
+            .max(1)
+        {
+            fixture
+                .app_state
+                .provider_circuit
+                .record_provider_failure(
+                    fixture.provider.id,
+                    "forced test failure".to_string(),
+                    None,
+                )
+                .await
+                .expect("forced provider failure should be recorded");
+        }
+        let open_snapshot = fixture
+            .app_state
+            .provider_circuit
+            .get_provider_health_snapshot(fixture.provider.id)
+            .await
+            .expect("provider health snapshot should load");
+        assert_eq!(open_snapshot.status, ProviderHealthStatus::Open);
+
+        let request = build_json_request(
+            "/openai/v1/chat/completions",
+            &[(
+                "authorization",
+                format!("Bearer {}", fixture.api_key.api_key),
+            )],
+            json!({
+                "model": fixture.requested_model(),
+                "messages": [{"role": "user", "content": "hi"}]
+            }),
+        );
+
+        let response = fixture.send(request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value =
+            serde_json::from_slice(&response_body_bytes(response).await).expect("proxy body json");
+        assert_eq!(body["choices"][0]["message"]["content"], "direct ok");
+        assert_eq!(upstream.captured_requests().await.len(), 1);
+
+        let recovered_snapshot = fixture
+            .app_state
+            .provider_circuit
+            .get_provider_health_snapshot(fixture.provider.id)
+            .await
+            .expect("provider health snapshot should load");
+        assert_eq!(recovered_snapshot.status, ProviderHealthStatus::Healthy);
+        assert_eq!(recovered_snapshot.consecutive_failures, 0);
+
+        let log = fixture.latest_log().await;
+        assert_eq!(log.overall_status, RequestStatus::Success);
+        assert_eq!(log.final_provider_id, Some(fixture.provider.id));
+        assert_eq!(log.attempt_count, 1);
+        assert_eq!(log.fallback_count, 0);
+
+        let attempts = fixture.attempts_for_log(log.id).await;
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(attempts[0].attempt_status, RequestAttemptStatus::Success);
+        assert_eq!(attempts[0].scheduler_action, SchedulerAction::ReturnSuccess);
+        assert_ne!(
+            attempts[0].error_code.as_deref(),
+            Some("provider_open_skipped")
+        );
+
+        fixture.cleanup().await;
+    });
+}
+
+#[test]
+fn provider_governance_open_single_route_candidate_executes_when_no_fallback_exists() {
+    run_integration_test(|test_db_context| async move {
+        if !CONFIG.provider_governance.is_enabled() {
+            eprintln!("skipping provider governance single-route scenario: governance disabled");
+            return;
+        }
+
+        let Some(upstream) = spawn_test_upstream_or_skip(|request| {
+            assert_eq!(request.path, "/v1/chat/completions");
+            UpstreamReply::json(
+                StatusCode::OK,
+                json!({
+                    "id": "chatcmpl-single-route-open",
+                    "object": "chat.completion",
+                    "model": "single-route-open-model",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "single route ok"},
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {
+                        "prompt_tokens": 3,
+                        "completion_tokens": 2,
+                        "total_tokens": 5
+                    }
+                }),
+            )
+        })
+        .await
+        else {
+            return;
+        };
+
+        let fixture = TestFixture::new(
+            test_db_context.clone(),
+            ProviderType::Openai,
+            format!("{}/v1", upstream.base_url),
+            None,
+            Some("single-route-open-model".to_string()),
+        )
+        .await;
+        let route_name = format!("proxy-int-single-open-route-{}", ID_GENERATOR.generate_id());
+        fixture.create_route(&route_name).await;
+
+        for _ in 0..CONFIG
+            .provider_governance
+            .consecutive_failure_threshold
+            .max(1)
+        {
+            fixture
+                .app_state
+                .provider_circuit
+                .record_provider_failure(
+                    fixture.provider.id,
+                    "forced test failure".to_string(),
+                    None,
+                )
+                .await
+                .expect("forced provider failure should be recorded");
+        }
+
+        let request = build_json_request(
+            "/openai/v1/chat/completions",
+            &[(
+                "authorization",
+                format!("Bearer {}", fixture.api_key.api_key),
+            )],
+            json!({
+                "model": route_name.clone(),
+                "messages": [{"role": "user", "content": "hi"}]
+            }),
+        );
+
+        let response = fixture.send(request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value =
+            serde_json::from_slice(&response_body_bytes(response).await).expect("proxy body json");
+        assert_eq!(body["choices"][0]["message"]["content"], "single route ok");
+        assert_eq!(upstream.captured_requests().await.len(), 1);
+
+        let recovered_snapshot = fixture
+            .app_state
+            .provider_circuit
+            .get_provider_health_snapshot(fixture.provider.id)
+            .await
+            .expect("provider health snapshot should load");
+        assert_eq!(recovered_snapshot.status, ProviderHealthStatus::Healthy);
+
+        let log = fixture.latest_log().await;
+        assert_eq!(log.overall_status, RequestStatus::Success);
+        assert_eq!(
+            log.resolved_route_name.as_deref(),
+            Some(route_name.as_str())
+        );
+        assert_eq!(log.attempt_count, 1);
+        assert_eq!(log.fallback_count, 0);
+
+        let attempts = fixture.attempts_for_log(log.id).await;
+        assert_eq!(attempts.len(), 1);
+        assert_eq!(attempts[0].attempt_status, RequestAttemptStatus::Success);
+        assert_eq!(attempts[0].scheduler_action, SchedulerAction::ReturnSuccess);
+        assert_ne!(
+            attempts[0].error_code.as_deref(),
+            Some("provider_open_skipped")
+        );
+
+        fixture.cleanup().await;
+    });
+}
+
+#[test]
 fn gateway_replay_preview_skips_open_candidate_and_materializes_fallback_without_upstream_call() {
     run_integration_test(|test_db_context| async move {
         if !CONFIG.provider_governance.is_enabled() {
@@ -3217,6 +3632,87 @@ fn upstream_errors_are_mapped_and_persisted_in_request_logs() {
         );
         assert_eq!(attempts[1].http_status, Some(429));
         assert_eq!(upstream.captured_requests().await.len(), 2);
+
+        fixture.cleanup().await;
+    });
+}
+
+#[test]
+fn upstream_connect_failures_persist_gateway_error_body_in_attempt_bundle() {
+    run_integration_test(|test_db_context| async move {
+        let listener = match TcpListener::bind("127.0.0.1:0").await {
+            Ok(listener) => listener,
+            Err(err) if err.kind() == ErrorKind::PermissionDenied => {
+                eprintln!(
+                    "skipping upstream connect failure scenario: listener bind denied: {}",
+                    err
+                );
+                return;
+            }
+            Err(err) => panic!("temporary listener should bind: {err}"),
+        };
+        let unavailable_addr = listener
+            .local_addr()
+            .expect("temporary listener should have an address");
+        drop(listener);
+
+        let fixture = TestFixture::new(
+            test_db_context.clone(),
+            ProviderType::Openai,
+            format!("http://{unavailable_addr}/v1"),
+            None,
+            Some("unavailable-upstream-model".to_string()),
+        )
+        .await;
+        let request = build_json_request(
+            "/openai/v1/chat/completions",
+            &[(
+                "authorization",
+                format!("Bearer {}", fixture.api_key.api_key),
+            )],
+            json!({
+                "model": fixture.requested_model(),
+                "messages": [{"role": "user", "content": "hi"}]
+            }),
+        );
+
+        let response = fixture.send(request).await;
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body: Value =
+            serde_json::from_slice(&response_body_bytes(response).await).expect("proxy body json");
+        assert_eq!(body["code"], "upstream_error");
+
+        let log = fixture.latest_log().await;
+        assert_eq!(log.overall_status, RequestStatus::Error);
+        assert_eq!(log.final_error_code.as_deref(), Some("upstream_error"));
+        assert_eq!(log.attempt_count, 2);
+        assert!(log.bundle_storage_key.is_some());
+
+        let attempts = fixture.attempts_for_log(log.id).await;
+        assert_eq!(attempts.len(), 2);
+        assert!(attempts.iter().all(|attempt| attempt.http_status.is_none()));
+        assert!(
+            attempts
+                .iter()
+                .all(|attempt| attempt.llm_response_blob_id.is_some())
+        );
+
+        let bundle = bundle_for_log(&log).await;
+        assert_eq!(bundle.attempt_sections.len(), 2);
+        for attempt_section in &bundle.attempt_sections {
+            let error_body = String::from_utf8(
+                bundle_blob_bytes(
+                    &bundle,
+                    attempt_section
+                        .llm_response_blob_id
+                        .expect("gateway error body should be persisted"),
+                )
+                .to_vec(),
+            )
+            .expect("gateway error body should be utf8");
+            assert!(error_body.contains("[upstream_error]"));
+            assert!(error_body.contains("could not connect to upstream"));
+        }
 
         fixture.cleanup().await;
     });

--- a/server/src/proxy/provider_governance.rs
+++ b/server/src/proxy/provider_governance.rs
@@ -19,12 +19,21 @@ pub(super) async fn ensure_provider_request_allowed(
     app_state: &AppState,
     provider_id: i64,
     provider_label: &str,
+    next_candidate_available: bool,
 ) -> Result<Option<ProviderCircuitProbePermit>, ProviderGovernanceCheckError> {
-    match app_state
-        .provider_circuit
-        .allow_provider_request(provider_id)
-        .await
-    {
+    let decision = if next_candidate_available {
+        app_state
+            .provider_circuit
+            .allow_provider_request(provider_id)
+            .await
+    } else {
+        app_state
+            .provider_circuit
+            .allow_last_candidate_request(provider_id)
+            .await
+    };
+
+    match decision {
         Ok(decision) => {
             if !decision.allowed {
                 let Some(rejection) = decision.rejection else {
@@ -39,10 +48,17 @@ pub(super) async fn ensure_provider_request_allowed(
             }
 
             if decision.snapshot.status == ProviderHealthStatus::HalfOpen {
-                info!(
-                    "Provider governance entering half-open probe: provider_id={}, provider={}",
-                    provider_id, provider_label
-                );
+                if next_candidate_available {
+                    info!(
+                        "Provider governance entering half-open probe: provider_id={}, provider={}",
+                        provider_id, provider_label
+                    );
+                } else {
+                    info!(
+                        "Provider governance entering last-candidate probe: provider_id={}, provider={}",
+                        provider_id, provider_label
+                    );
+                }
             }
             Ok(decision.probe_permit)
         }

--- a/server/src/proxy/runtime/executor.rs
+++ b/server/src/proxy/runtime/executor.rs
@@ -157,14 +157,23 @@ async fn ensure_provider_governance_for_policy(
     execution_policy: RuntimeExecutionPolicy,
     provider_id: i64,
     provider_label: &str,
+    next_candidate_available: bool,
 ) -> Result<Option<ProviderCircuitProbePermit>, ProviderGovernanceCheckError> {
     if execution_policy.uses_mutating_provider_governance() {
-        ensure_provider_request_allowed(app_state, provider_id, provider_label).await
+        ensure_provider_request_allowed(
+            app_state,
+            provider_id,
+            provider_label,
+            next_candidate_available,
+        )
+        .await
     } else {
         debug_assert!(execution_policy.uses_read_only_provider_governance());
-        preview_provider_request_allowed(app_state, provider_id)
-            .await
-            .map(|_| None)
+        match preview_provider_request_allowed(app_state, provider_id).await {
+            Ok(()) => Ok(None),
+            Err(ProviderGovernanceCheckError::Rejected(_)) if !next_candidate_available => Ok(None),
+            Err(err) => Err(err),
+        }
     }
 }
 
@@ -522,6 +531,7 @@ pub(in crate::proxy) async fn execute_attempt(
         execution_policy,
         candidate.provider.id,
         materialized.model_str.as_str(),
+        next_candidate_available,
     )
     .await
     {
@@ -718,6 +728,14 @@ mod tests {
             })
         }
 
+        async fn allow_last_candidate_request(
+            &self,
+            provider_id: i64,
+            config: &ProviderGovernanceConfig,
+        ) -> Result<ProviderCircuitDecision, ProviderCircuitError> {
+            self.allow_request(provider_id, config).await
+        }
+
         async fn record_success(
             &self,
             _provider_id: i64,
@@ -755,6 +773,14 @@ mod tests {
             Err(ProviderCircuitError::Backend(
                 "redis unavailable".to_string(),
             ))
+        }
+
+        async fn allow_last_candidate_request(
+            &self,
+            provider_id: i64,
+            config: &ProviderGovernanceConfig,
+        ) -> Result<ProviderCircuitDecision, ProviderCircuitError> {
+            self.allow_request(provider_id, config).await
         }
 
         async fn record_success(
@@ -823,10 +849,39 @@ mod tests {
             RuntimeExecutionPolicy::ReplayLive,
             7,
             "model",
+            true,
         )
         .await;
 
         assert!(result.is_err());
+        assert_eq!(store.allow_calls.load(Ordering::SeqCst), 0);
+        let snapshot = app_state
+            .provider_circuit
+            .get_provider_health_snapshot(7)
+            .await
+            .expect("snapshot should load");
+        assert_eq!(snapshot.status, ProviderHealthStatus::Open);
+        assert!(!snapshot.half_open_probe_in_flight);
+    }
+
+    #[tokio::test]
+    async fn replay_live_provider_governance_allows_open_last_candidate_without_mutating() {
+        let store = Arc::new(RecordingProviderCircuitStore::new(
+            RecordingProviderCircuitStore::open_snapshot(),
+        ));
+        let mut app_state = AppState::new().await;
+        app_state.provider_circuit = Arc::new(ProviderCircuitService::new(store.clone()));
+
+        let result = ensure_provider_governance_for_policy(
+            &app_state,
+            RuntimeExecutionPolicy::ReplayLive,
+            7,
+            "model",
+            false,
+        )
+        .await;
+
+        assert!(matches!(result, Ok(None)));
         assert_eq!(store.allow_calls.load(Ordering::SeqCst), 0);
         let snapshot = app_state
             .provider_circuit
@@ -850,6 +905,7 @@ mod tests {
             RuntimeExecutionPolicy::Normal,
             7,
             "model",
+            true,
         )
         .await;
 
@@ -876,6 +932,7 @@ mod tests {
             RuntimeExecutionPolicy::Normal,
             7,
             "model",
+            true,
         )
         .await;
 

--- a/server/src/proxy/runtime/replay_adapter.rs
+++ b/server/src/proxy/runtime/replay_adapter.rs
@@ -33,7 +33,10 @@ use crate::{
             policy::{RuntimeExecutionPolicy, RuntimeLogMode},
             request_patch::load_runtime_request_patch_trace,
             route_resolver::{ExecutionCandidate, ExecutionPlan, build_execution_plan},
-            scheduler::{SchedulerExecutionFailure, SchedulerExecutionInput, schedule_execution},
+            scheduler::{
+                SchedulerExecutionFailure, SchedulerExecutionInput,
+                next_accessible_candidate_available, schedule_execution,
+            },
         },
         util::serialize_downstream_request_headers_for_log,
         utility::{UtilityOperation, validate_utility_target},
@@ -462,8 +465,14 @@ async fn materialize_gateway_replay_request(
         let mut same_candidate_retry_count = 0u32;
 
         loop {
-            let next_candidate_available = candidate_index + 1 < execution_plan.candidates.len()
-                && candidate_index + 1 < candidate_budget;
+            let next_candidate_available = next_accessible_candidate_available(
+                candidate_index,
+                &execution_plan.candidates,
+                candidate_budget,
+                &input.api_key,
+                &app_state,
+            )
+            .await;
             match materialize_gateway_replay_candidate(
                 &app_state,
                 &input,
@@ -709,6 +718,7 @@ async fn materialize_gateway_replay_candidate(
 
     match preview_provider_request_allowed(app_state, candidate.provider.id).await {
         Ok(()) => {}
+        Err(ProviderGovernanceCheckError::Rejected(_)) if !next_candidate_available => {}
         Err(ProviderGovernanceCheckError::Rejected(rejection)) => {
             attempt.completed_at = Some(Utc::now().timestamp_millis());
             attempt.started_at = None;

--- a/server/src/proxy/runtime/scheduler.rs
+++ b/server/src/proxy/runtime/scheduler.rs
@@ -10,6 +10,7 @@ use tokio::time::sleep;
 use crate::{
     proxy::{
         ProxyError,
+        auth::check_access_control,
         cancellation::ProxyCancellationContext,
         logging::RequestLogContext,
         runtime::{
@@ -29,7 +30,7 @@ use crate::{
                 record_no_candidate_failure,
             },
             policy::{RuntimeExecutionPolicy, RuntimeLogMode},
-            route_resolver::ExecutionPlan,
+            route_resolver::{ExecutionCandidate, ExecutionPlan},
         },
     },
     schema::enum_def::{LlmApiType, SchedulerAction},
@@ -90,6 +91,28 @@ fn next_candidate_available(
     candidate_budget: usize,
 ) -> bool {
     candidate_index + 1 < candidate_count && candidate_index + 1 < candidate_budget
+}
+
+pub(super) async fn next_accessible_candidate_available(
+    candidate_index: usize,
+    candidates: &[ExecutionCandidate],
+    candidate_budget: usize,
+    api_key: &CacheApiKey,
+    app_state: &Arc<AppState>,
+) -> bool {
+    if !next_candidate_available(candidate_index, candidates.len(), candidate_budget) {
+        return false;
+    }
+
+    let next_candidate = &candidates[candidate_index + 1];
+    check_access_control(
+        api_key,
+        &next_candidate.provider,
+        &next_candidate.model,
+        app_state,
+    )
+    .await
+    .is_ok()
 }
 
 fn scheduler_step_for_attempt(
@@ -245,11 +268,14 @@ pub(in crate::proxy) async fn schedule_execution(
         let mut same_candidate_retry_count = 0u32;
 
         loop {
-            let next_candidate_available = next_candidate_available(
+            let next_candidate_available = next_accessible_candidate_available(
                 candidate_index,
-                execution_plan.candidates.len(),
+                &execution_plan.candidates,
                 candidate_budget,
-            );
+                &api_key,
+                &app_state,
+            )
+            .await;
             let result = Box::pin(execute_attempt(
                 Arc::clone(&app_state),
                 AttemptExecutionInput {

--- a/server/src/proxy/runtime/transport/mod.rs
+++ b/server/src/proxy/runtime/transport/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     proxy::{
         ProxyError,
         cancellation::{CancellationDropGuard, ProxyCancellationContext},
-        logging::RequestLogContext,
+        logging::{LoggedBody, RequestLogContext},
         provider_governance::record_provider_failure,
         runtime::{
             api_key_lease::ApiKeyRequestLeaseFinalizer,
@@ -78,6 +78,24 @@ pub(in crate::proxy) struct ProxyRequestFailure {
 pub(in crate::proxy) struct ReasoningContinuationCaptureContext {
     pub scope: ReasoningContinuationScope,
     pub feature_enabled: bool,
+}
+
+fn finalize_send_failure_log_context(
+    context: &mut RequestLogContext,
+    url: &str,
+    completed_at: i64,
+    cost_catalog_version: Option<&CacheCostCatalogVersion>,
+    proxy_error: &ProxyError,
+) {
+    context.request_url = Some(url.to_string());
+    context.completion_ts = Some(completed_at);
+    context.cost_catalog_version = cost_catalog_version.cloned();
+    context.overall_status = if matches!(proxy_error, ProxyError::ClientCancelled(_)) {
+        RequestStatus::Cancelled
+    } else {
+        RequestStatus::Error
+    };
+    context.llm_response_body = Some(LoggedBody::from_bytes(Bytes::from(proxy_error.to_string())));
 }
 
 // Builds the HTTP client, sends the request to the LLM, and passes the response to be handled.
@@ -154,14 +172,13 @@ pub(in crate::proxy) async fn send_materialized_request(
             let completed_at = Utc::now().timestamp_millis();
 
             let mut context = log_context.lock().await;
-            context.request_url = Some(url.clone());
-            context.completion_ts = Some(completed_at);
-            context.cost_catalog_version = cost_catalog_version.clone();
-            context.overall_status = if matches!(proxy_error, ProxyError::ClientCancelled(_)) {
-                RequestStatus::Cancelled
-            } else {
-                RequestStatus::Error
-            };
+            finalize_send_failure_log_context(
+                &mut context,
+                &url,
+                completed_at,
+                cost_catalog_version.as_ref(),
+                &proxy_error,
+            );
             record_immediate_completion_if_allowed(
                 &app_state,
                 &context,
@@ -264,6 +281,7 @@ mod tests {
     use super::{
         ReasoningContinuationCaptureContext,
         client::send_with_first_byte_timeout,
+        finalize_send_failure_log_context,
         non_stream::{
             capture_non_stream_reasoning_continuation,
             reasoning_capture_transform_diagnostics as non_stream_capture_transform_diagnostics,
@@ -1117,6 +1135,50 @@ mod tests {
             .unwrap();
         let returned_body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert_eq!(returned_body, body);
+    }
+
+    #[test]
+    fn finalize_send_failure_log_context_records_gateway_error_body_without_upstream_status() {
+        let mut context = make_log_context();
+        let cost_catalog_version = CacheCostCatalogVersion {
+            id: 8,
+            catalog_id: 4,
+            version: "v2".to_string(),
+            currency: "USD".to_string(),
+            source: None,
+            effective_from: 0,
+            effective_until: None,
+            is_enabled: true,
+            components: vec![],
+        };
+        let proxy_error = ProxyError::BadGateway(
+            "LLM request could not connect to upstream: error sending request".to_string(),
+        );
+
+        finalize_send_failure_log_context(
+            &mut context,
+            "https://api.deepseek.com//chat/completions",
+            6789,
+            Some(&cost_catalog_version),
+            &proxy_error,
+        );
+
+        assert_eq!(
+            context.request_url.as_deref(),
+            Some("https://api.deepseek.com//chat/completions")
+        );
+        assert_eq!(context.llm_status, None);
+        assert_eq!(context.completion_ts, Some(6789));
+        assert_eq!(context.overall_status, RequestStatus::Error);
+        assert_eq!(context.cost_catalog_version.as_ref().map(|v| v.id), Some(8));
+        match context.llm_response_body.as_ref() {
+            Some(LoggedBody::InMemory { bytes, .. }) => {
+                let body = std::str::from_utf8(bytes).expect("error body should be utf8");
+                assert!(body.contains("[upstream_error] LLM request could not connect"));
+            }
+            other => panic!("unexpected llm_response_body: {other:?}"),
+        }
+        assert!(context.user_response_body.is_none());
     }
 
     #[tokio::test]

--- a/server/src/service/runtime/provider_circuit/contract_tests.rs
+++ b/server/src/service/runtime/provider_circuit/contract_tests.rs
@@ -360,6 +360,143 @@ async fn assert_failure_reopen_contract(store: Arc<dyn ProviderCircuitStore>) {
     assert_eq!(snapshot.last_error.as_deref(), Some("half-open timeout"));
 }
 
+async fn assert_last_candidate_probe_success_closes_open_contract(
+    store: Arc<dyn ProviderCircuitStore>,
+) {
+    let config = config(1, 60);
+    let provider_id = 712;
+    store
+        .record_failure(provider_id, &config, "timeout".to_string(), None)
+        .await
+        .expect("failure should open circuit");
+
+    let decision = store
+        .allow_last_candidate_request(provider_id, &config)
+        .await
+        .expect("last candidate should be evaluated atomically");
+    assert!(decision.allowed);
+    assert_eq!(decision.snapshot.status, ProviderHealthStatus::HalfOpen);
+    let permit = decision
+        .probe_permit
+        .as_ref()
+        .expect("last candidate probe should include a permit");
+
+    let concurrent = store
+        .allow_last_candidate_request(provider_id, &config)
+        .await
+        .expect("concurrent last candidate should be evaluated");
+    assert!(!concurrent.allowed);
+    assert_eq!(
+        concurrent.rejection,
+        Some(ProviderCircuitRejection::HalfOpenProbeInFlight)
+    );
+
+    let snapshot = store
+        .record_success(provider_id, &config, Some(permit))
+        .await
+        .expect("last candidate probe success should close circuit");
+
+    assert_eq!(snapshot.status, ProviderHealthStatus::Healthy);
+    assert_eq!(snapshot.consecutive_failures, 0);
+    assert!(!snapshot.half_open_probe_in_flight);
+    assert!(snapshot.opened_at.is_none());
+    assert!(snapshot.last_error.is_none());
+    assert!(snapshot.last_recovered_at.is_some());
+
+    let stale_completion = store
+        .record_failure(
+            provider_id,
+            &config,
+            "stale probe failure".to_string(),
+            Some(permit),
+        )
+        .await
+        .expect("stale probe completion should be ignored");
+    assert_eq!(stale_completion.status, ProviderHealthStatus::Healthy);
+    assert_eq!(stale_completion.consecutive_failures, 0);
+    assert!(stale_completion.last_error.is_none());
+}
+
+async fn assert_last_candidate_probe_failure_reopens_contract(
+    store: Arc<dyn ProviderCircuitStore>,
+) {
+    let config = config(1, 60);
+    let provider_id = 713;
+    store
+        .record_failure(provider_id, &config, "timeout".to_string(), None)
+        .await
+        .expect("failure should open circuit");
+
+    let decision = store
+        .allow_last_candidate_request(provider_id, &config)
+        .await
+        .expect("last candidate should be evaluated atomically");
+    let permit = decision
+        .probe_permit
+        .as_ref()
+        .expect("last candidate probe should include a permit");
+    let snapshot = store
+        .record_failure(
+            provider_id,
+            &config,
+            "last candidate timeout".to_string(),
+            Some(permit),
+        )
+        .await
+        .expect("last candidate probe failure should open circuit");
+
+    assert_eq!(snapshot.status, ProviderHealthStatus::Open);
+    assert_eq!(snapshot.consecutive_failures, 2);
+    assert!(!snapshot.half_open_probe_in_flight);
+    assert!(snapshot.opened_at.is_some());
+    assert_eq!(
+        snapshot.last_error.as_deref(),
+        Some("last candidate timeout")
+    );
+}
+
+async fn assert_probe_permit_cannot_complete_another_provider_contract(
+    store: Arc<dyn ProviderCircuitStore>,
+) {
+    let config = config(1, 60);
+    let permit_provider_id = 714;
+    let other_provider_id = 715;
+    for provider_id in [permit_provider_id, other_provider_id] {
+        store
+            .record_failure(provider_id, &config, "timeout".to_string(), None)
+            .await
+            .expect("failure should open circuit");
+    }
+    let decision = store
+        .allow_last_candidate_request(permit_provider_id, &config)
+        .await
+        .expect("last candidate should be evaluated atomically");
+    let permit = decision
+        .probe_permit
+        .as_ref()
+        .expect("last candidate probe should include a permit");
+
+    let success = store
+        .record_success(other_provider_id, &config, Some(permit))
+        .await
+        .expect("mismatched success should be ignored");
+    assert_eq!(success.status, ProviderHealthStatus::Open);
+    assert_eq!(success.consecutive_failures, 1);
+
+    let failure = store
+        .record_failure(
+            other_provider_id,
+            &config,
+            "mismatched failure".to_string(),
+            Some(permit),
+        )
+        .await
+        .expect("mismatched failure should be ignored");
+    assert_eq!(failure.status, ProviderHealthStatus::Open);
+    assert_eq!(failure.consecutive_failures, 1);
+    assert_eq!(failure.last_error.as_deref(), Some("timeout"));
+}
+
 #[tokio::test]
 async fn memory_store_opens_after_threshold_failures() {
     assert_threshold_open_contract(Arc::new(MemoryProviderCircuitStore::default())).await;
@@ -394,6 +531,30 @@ async fn memory_store_matching_probe_success_closes_circuit() {
 #[tokio::test]
 async fn memory_store_matching_probe_failure_reopens_circuit() {
     assert_failure_reopen_contract(Arc::new(MemoryProviderCircuitStore::default())).await;
+}
+
+#[tokio::test]
+async fn memory_store_last_candidate_probe_is_single_flight_and_closes_on_success() {
+    assert_last_candidate_probe_success_closes_open_contract(Arc::new(
+        MemoryProviderCircuitStore::default(),
+    ))
+    .await;
+}
+
+#[tokio::test]
+async fn memory_store_last_candidate_probe_failure_opens_circuit() {
+    assert_last_candidate_probe_failure_reopens_contract(Arc::new(
+        MemoryProviderCircuitStore::default(),
+    ))
+    .await;
+}
+
+#[tokio::test]
+async fn memory_store_probe_permit_cannot_complete_another_provider() {
+    assert_probe_permit_cannot_complete_another_provider_contract(Arc::new(
+        MemoryProviderCircuitStore::default(),
+    ))
+    .await;
 }
 
 #[tokio::test]
@@ -463,6 +624,42 @@ async fn redis_store_matching_probe_failure_reopens_circuit() {
         return;
     };
     assert_failure_reopen_contract(Arc::new(redis_store(pool, Duration::from_secs(30)))).await;
+}
+
+#[tokio::test]
+async fn redis_store_last_candidate_probe_is_single_flight_and_closes_on_success() {
+    let Some(pool) = redis_pool_or_skip().await else {
+        return;
+    };
+    assert_last_candidate_probe_success_closes_open_contract(Arc::new(redis_store(
+        pool,
+        Duration::from_secs(30),
+    )))
+    .await;
+}
+
+#[tokio::test]
+async fn redis_store_last_candidate_probe_failure_opens_circuit() {
+    let Some(pool) = redis_pool_or_skip().await else {
+        return;
+    };
+    assert_last_candidate_probe_failure_reopens_contract(Arc::new(redis_store(
+        pool,
+        Duration::from_secs(30),
+    )))
+    .await;
+}
+
+#[tokio::test]
+async fn redis_store_probe_permit_cannot_complete_another_provider() {
+    let Some(pool) = redis_pool_or_skip().await else {
+        return;
+    };
+    assert_probe_permit_cannot_complete_another_provider_contract(Arc::new(redis_store(
+        pool,
+        Duration::from_secs(30),
+    )))
+    .await;
 }
 
 #[tokio::test]

--- a/server/src/service/runtime/provider_circuit/memory_store.rs
+++ b/server/src/service/runtime/provider_circuit/memory_store.rs
@@ -52,6 +52,29 @@ impl ProviderCircuitStore for MemoryProviderCircuitStore {
         Ok(provider_state.allow_request(provider_id, config, now_ms, self.probe_lease_ttl))
     }
 
+    async fn allow_last_candidate_request(
+        &self,
+        provider_id: i64,
+        config: &ProviderGovernanceConfig,
+    ) -> Result<ProviderCircuitDecision, ProviderCircuitError> {
+        if !config.is_enabled() {
+            return Ok(ProviderCircuitDecision::allowed(
+                ProviderHealthSnapshot::synthetic_healthy(),
+                None,
+            ));
+        }
+
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let mut state = self.inner.lock().await;
+        let provider_state = state.entry(provider_id).or_default();
+        Ok(provider_state.allow_last_candidate_request(
+            provider_id,
+            config,
+            now_ms,
+            self.probe_lease_ttl,
+        ))
+    }
+
     async fn record_success(
         &self,
         provider_id: i64,

--- a/server/src/service/runtime/provider_circuit/redis_store.rs
+++ b/server/src/service/runtime/provider_circuit/redis_store.rs
@@ -23,6 +23,7 @@ local probe_lease_ttl_ms = tonumber(ARGV[4])
 local state_ttl_seconds = tonumber(ARGV[5])
 local decision_id = ARGV[6]
 local lease_id = ARGV[7]
+local allow_last_candidate_probe = ARGV[8] == '1'
 
 local function raw(field)
     return redis.call('HGET', state_key, field) or ''
@@ -107,7 +108,7 @@ if status == 'open' then
     local opened_at = tonumber(redis.call('HGET', state_key, 'opened_at')) or now_ms
     local elapsed_ms = now_ms - opened_at
     local retry_after_ms = open_cooldown_ms - elapsed_ms
-    if retry_after_ms > 0 then
+    if retry_after_ms > 0 and not allow_last_candidate_probe then
         return result(0, 'open_cooldown', retry_after_ms, -1)
     end
 
@@ -243,6 +244,8 @@ if status == 'half_open' then
     if permit_provider_id ~= provider_id or not active_lease_id or active_lease_id ~= permit_lease_id then
         return result()
     end
+elseif permit_lease_id ~= '' then
+    return result()
 end
 
 local was_unhealthy = status ~= 'healthy'
@@ -351,6 +354,8 @@ if status == 'half_open' then
     if not half_open_probe_failed then
         return result()
     end
+elseif permit_lease_id ~= '' then
+    return result()
 end
 
 local consecutive_failures = hnum('consecutive_failures') + 1
@@ -487,14 +492,12 @@ impl RedisProviderCircuitStore {
             command.arg("").arg("");
         }
     }
-}
 
-#[async_trait]
-impl ProviderCircuitStore for RedisProviderCircuitStore {
-    async fn allow_request(
+    async fn evaluate_allow_request(
         &self,
         provider_id: i64,
         config: &ProviderGovernanceConfig,
+        allow_last_candidate_probe: bool,
     ) -> Result<ProviderCircuitDecision, ProviderCircuitError> {
         let now_ms = Utc::now().timestamp_millis();
         let decision_id = Uuid::new_v4().to_string();
@@ -516,11 +519,32 @@ impl ProviderCircuitStore for RedisProviderCircuitStore {
             .arg(self.state_ttl_seconds())
             .arg(&decision_id)
             .arg(&lease_id)
+            .arg(if allow_last_candidate_probe { "1" } else { "0" })
             .query_async(&mut *conn)
             .await
             .map_err(|err| Self::redis_error("provider circuit allow script failed", err))?;
 
         allow_result_to_domain(provider_id, decision_id, lease_id, now_ms, result)
+    }
+}
+
+#[async_trait]
+impl ProviderCircuitStore for RedisProviderCircuitStore {
+    async fn allow_request(
+        &self,
+        provider_id: i64,
+        config: &ProviderGovernanceConfig,
+    ) -> Result<ProviderCircuitDecision, ProviderCircuitError> {
+        self.evaluate_allow_request(provider_id, config, false)
+            .await
+    }
+
+    async fn allow_last_candidate_request(
+        &self,
+        provider_id: i64,
+        config: &ProviderGovernanceConfig,
+    ) -> Result<ProviderCircuitDecision, ProviderCircuitError> {
+        self.evaluate_allow_request(provider_id, config, true).await
     }
 
     async fn record_success(

--- a/server/src/service/runtime/provider_circuit/service.rs
+++ b/server/src/service/runtime/provider_circuit/service.rs
@@ -91,6 +91,23 @@ impl ProviderCircuitService {
         self.store.allow_request(provider_id, &config).await
     }
 
+    pub async fn allow_last_candidate_request(
+        &self,
+        provider_id: i64,
+    ) -> Result<ProviderCircuitDecision, ProviderCircuitError> {
+        let config = self.config_manager.current().await;
+        if !config.is_enabled() {
+            return Ok(ProviderCircuitDecision::allowed(
+                ProviderHealthSnapshot::synthetic_healthy(),
+                None,
+            ));
+        }
+
+        self.store
+            .allow_last_candidate_request(provider_id, &config)
+            .await
+    }
+
     pub async fn record_provider_success(
         &self,
         provider_id: i64,

--- a/server/src/service/runtime/provider_circuit/types.rs
+++ b/server/src/service/runtime/provider_circuit/types.rs
@@ -247,6 +247,27 @@ impl ProviderHealthState {
         now_ms: i64,
         probe_lease_ttl: Duration,
     ) -> ProviderCircuitDecision {
+        self.allow_request_with_cooldown_policy(provider_id, config, now_ms, probe_lease_ttl, true)
+    }
+
+    pub(crate) fn allow_last_candidate_request(
+        &mut self,
+        provider_id: i64,
+        config: &ProviderGovernanceConfig,
+        now_ms: i64,
+        probe_lease_ttl: Duration,
+    ) -> ProviderCircuitDecision {
+        self.allow_request_with_cooldown_policy(provider_id, config, now_ms, probe_lease_ttl, false)
+    }
+
+    fn allow_request_with_cooldown_policy(
+        &mut self,
+        provider_id: i64,
+        config: &ProviderGovernanceConfig,
+        now_ms: i64,
+        probe_lease_ttl: Duration,
+        respect_open_cooldown: bool,
+    ) -> ProviderCircuitDecision {
         if !config.is_enabled() {
             return ProviderCircuitDecision::allowed(
                 ProviderHealthSnapshot::synthetic_healthy(),
@@ -262,7 +283,7 @@ impl ProviderHealthState {
             }
             ProviderHealthStatus::Open => {
                 let retry_after = self.retry_after_for_open(config, now_ms);
-                if !retry_after.is_zero() {
+                if respect_open_cooldown && !retry_after.is_zero() {
                     return ProviderCircuitDecision::rejected(
                         self.snapshot(),
                         ProviderCircuitRejection::OpenCooldown,
@@ -299,10 +320,16 @@ impl ProviderHealthState {
         }
 
         self.prune_expired_probe(now_ms);
-        if self.status == ProviderHealthStatus::Open {
+        let matching_probe =
+            self.status == ProviderHealthStatus::HalfOpen && self.probe_permit_matches(permit);
+        if permit.is_some() && !matching_probe {
             return;
         }
-        if self.status == ProviderHealthStatus::HalfOpen && !self.probe_permit_matches(permit) {
+        if matches!(
+            self.status,
+            ProviderHealthStatus::Open | ProviderHealthStatus::HalfOpen
+        ) && !matching_probe
+        {
             return;
         }
 
@@ -332,6 +359,9 @@ impl ProviderHealthState {
 
         let half_open_probe_failed =
             self.status == ProviderHealthStatus::HalfOpen && self.probe_permit_matches(permit);
+        if permit.is_some() && !half_open_probe_failed {
+            return;
+        }
         if self.status == ProviderHealthStatus::HalfOpen && !half_open_probe_failed {
             return;
         }
@@ -353,6 +383,12 @@ impl ProviderHealthState {
 #[async_trait]
 pub trait ProviderCircuitStore: Send + Sync {
     async fn allow_request(
+        &self,
+        provider_id: i64,
+        config: &ProviderGovernanceConfig,
+    ) -> Result<ProviderCircuitDecision, ProviderCircuitError>;
+
+    async fn allow_last_candidate_request(
         &self,
         provider_id: i64,
         config: &ProviderGovernanceConfig,


### PR DESCRIPTION
## Summary

- make last-candidate provider recovery use an atomic Memory/Redis half-open lease instead of a locally forged bypass permit
- reject concurrent, stale, mismatched-lease, and cross-provider probe completions
- exclude ACL-denied candidates from fallback availability and keep replay governance read-only
- persist upstream connection failures in request attempt diagnostic bundles
- add provider circuit contract and proxy integration regressions

## Verification

- `cargo test -p cyder-api`: 1169 passed
- provider circuit contract tests against an isolated Redis 7 container: 43 passed
- provider governance integration tests: 4 passed
- upstream connection failure bundle integration test: 1 passed
- `cargo fmt --check`
- `cargo run -p cyder-api --bin log_lint`
- `npm --prefix front run build`
- `git diff --check`

S3/object-storage paths were not verified against a real S3-compatible environment.